### PR TITLE
feat(ui): add user-defined performance capacity threshold

### DIFF
--- a/src/components/inputs/AdvancedPanel.tsx
+++ b/src/components/inputs/AdvancedPanel.tsx
@@ -65,6 +65,8 @@ export function AdvancedPanel() {
     setFsType,
     setBackupRetention,
     setDailyChangeRate,
+    performanceThreshold,
+    setPerformanceThreshold,
   } = useConfigStore()
 
   // Get available controller options based on topology type (HBA for ZFS/vSAN/S2D, RAID for others)
@@ -236,6 +238,35 @@ export function AdvancedPanel() {
             formatValue={(v) => v.toFixed(2)}
           />
           <p className="text-xs text-slate-500">{t('power.pueHint')}</p>
+        </div>
+      </div>
+
+      {/* Capacity Management Section */}
+      <div className="space-y-4 pt-4 border-t border-surface-700">
+        <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
+          {t('capacityManagement.title')}
+        </h4>
+
+        <div className="space-y-2">
+          <Label
+            htmlFor="performance-threshold"
+            hint={`${Math.round(performanceThreshold * 100)}%`}
+            tooltip={th('advanced.performanceThreshold')}
+          >
+            {t('capacityManagement.performanceThreshold')}
+          </Label>
+          <Slider
+            id="performance-threshold"
+            value={performanceThreshold * 100}
+            min={50}
+            max={100}
+            step={5}
+            onChange={(v) => setPerformanceThreshold(v / 100)}
+            formatValue={(v) => `${v}%`}
+          />
+          <p className="text-xs text-slate-500">
+            {t('capacityManagement.performanceThresholdHint')}
+          </p>
         </div>
       </div>
 

--- a/src/components/layout/OutputDashboard.tsx
+++ b/src/components/layout/OutputDashboard.tsx
@@ -92,8 +92,16 @@ function ProgressBar({
 export function OutputDashboard() {
   const { t } = useTranslation('output')
   const { t: th } = useTranslation('help')
-  const { topology, zfsOptions, driveId, driveCount, hotSpares, controllerOptions, unitSystem } =
-    useConfigStore()
+  const {
+    topology,
+    zfsOptions,
+    driveId,
+    driveCount,
+    hotSpares,
+    controllerOptions,
+    unitSystem,
+    performanceThreshold,
+  } = useConfigStore()
   const formatBytes = useFormatBytes()
   const results = useCalculations()
   const selectedDrive = drives[driveId] || null
@@ -103,6 +111,10 @@ export function OutputDashboard() {
   const isDesktop = useIsDesktop()
 
   const { volumetry, performance, sustainability } = results
+
+  // Calculate operational limit when performance threshold is active
+  const operationalLimit =
+    performanceThreshold < 1.0 ? volumetry.usableCapacity * performanceThreshold : null
 
   // Resilience simulation - reduce iterations on mobile for battery/performance
   const {
@@ -228,13 +240,24 @@ export function OutputDashboard() {
               </div>
 
               {/* Metrics */}
-              <div className="grid grid-cols-3 gap-4 pt-4 border-t border-surface-700">
+              <div
+                className={`grid gap-4 pt-4 border-t border-surface-700 ${operationalLimit !== null ? 'grid-cols-4' : 'grid-cols-3'}`}
+              >
                 <MetricCard label={t('capacity.raw')}>
                   <AnimatedBytes value={volumetry.rawCapacity} />
                 </MetricCard>
                 <MetricCard label={t('capacity.usable')} color="text-primary-400">
                   <AnimatedBytes value={volumetry.usableCapacity} />
                 </MetricCard>
+                {operationalLimit !== null && (
+                  <MetricCard
+                    label={t('capacity.operationalLimit')}
+                    color="text-cyan-400"
+                    subvalue={`@ ${Math.round(performanceThreshold * 100)}%`}
+                  >
+                    <AnimatedBytes value={operationalLimit} />
+                  </MetricCard>
+                )}
                 <MetricCard
                   label={t('capacity.effective')}
                   color="text-green-400"

--- a/src/i18n/locales/de/advanced.json
+++ b/src/i18n/locales/de/advanced.json
@@ -56,5 +56,10 @@
     "reflinkHint": "Copy-on-Write-Klone fuer effiziente Backups",
     "backupRetention": "Backup-Aufbewahrung (Tage)",
     "dailyChangeRate": "Taegliche Aenderungsrate (%)"
+  },
+  "capacityManagement": {
+    "title": "Kapazitaetsverwaltung",
+    "performanceThreshold": "Leistungsschwelle",
+    "performanceThresholdHint": "Betriebskapazitaet begrenzen um Leistung zu erhalten (Standard 100%)"
   }
 }

--- a/src/i18n/locales/de/help.json
+++ b/src/i18n/locales/de/help.json
@@ -29,7 +29,8 @@
     "fsType": "Die Wahl des Dateisystems beeinflusst Overhead und Funktionen. ZFS hat ca. 3 % Slop-Space-Overhead. XFS/ReFS unterstuetzen Reflinks fuer effiziente Snapshots. Btrfs unterstuetzt Snapshots mit ca. 4 % Overhead.",
     "controller": "Der Storage-Controller oder HBA begrenzt die Gesamt-IOPS und den Durchsatz. Software-RAID nutzt die CPU fuer Paritaetsberechnungen. Hardware-RAID-Controller haben feste IOPS-/Durchsatz-Obergrenzen.",
     "backupRetention": "Anzahl der Tage, fuer die Backup-Kopien aufbewahrt werden. In Kombination mit der taeglichen Aenderungsrate wird der gesamte benoetigte Backup-Speicher bestimmt.",
-    "dailyChangeRate": "Prozentsatz der Daten, die sich taeglich aendern. Hoehere Aenderungsraten bedeuten groessere inkrementelle Backups und hoeheren Speicherverbrauch ueber den Aufbewahrungszeitraum."
+    "dailyChangeRate": "Prozentsatz der Daten, die sich taeglich aendern. Hoehere Aenderungsraten bedeuten groessere inkrementelle Backups und hoeheren Speicherverbrauch ueber den Aufbewahrungszeitraum.",
+    "performanceThreshold": "Die Leistungsschwelle begrenzt, wie voll der Speicher werden darf, bevor die Leistung abnimmt. Die meisten Speichersysteme werden langsamer, wenn sie sich der Kapazitaetsgrenze naehern. Eine Einstellung von 85% bedeutet, dass nur 85% der nutzbaren Kapazitaet als Betriebsgrenze angezeigt werden. Standard 100% (keine Begrenzung)."
   },
   "output": {
     "rawCapacity": "Gesamte physische Kapazitaet aller Laufwerke vor jeglichem Overhead. Berechnung: Laufwerkskapazitaet x Laufwerksanzahl x Serveranzahl.",

--- a/src/i18n/locales/de/output.json
+++ b/src/i18n/locales/de/output.json
@@ -4,6 +4,7 @@
     "raw": "Bruttokapazität",
     "usable": "Nutzbare Kapazität",
     "effective": "Effektive Kapazität",
+    "operationalLimit": "Betriebsgrenze",
     "afterCompression": "Nach Komprimierung",
     "efficiency": "Effizienz",
     "zfsBreakdown": "ZFS-Kapazitätsaufschlüsselung",

--- a/src/i18n/locales/en/advanced.json
+++ b/src/i18n/locales/en/advanced.json
@@ -56,5 +56,10 @@
     "reflinkHint": "Copy-on-write clones for backup efficiency",
     "backupRetention": "Backup Retention (Days)",
     "dailyChangeRate": "Daily Change Rate (%)"
+  },
+  "capacityManagement": {
+    "title": "Capacity Management",
+    "performanceThreshold": "Performance Threshold",
+    "performanceThresholdHint": "Limit operational capacity to maintain performance (default 100%)"
   }
 }

--- a/src/i18n/locales/en/help.json
+++ b/src/i18n/locales/en/help.json
@@ -29,7 +29,8 @@
     "fsType": "Filesystem choice affects overhead and features. ZFS has ~3% slop space overhead. XFS/ReFS support reflinks for efficient snapshots. Btrfs supports snapshots with ~4% overhead.",
     "controller": "Storage controller or HBA limits total IOPS and throughput. Software RAID uses CPU for parity calculations. Hardware RAID controllers have fixed IOPS/throughput ceilings.",
     "backupRetention": "Number of days to keep backup copies. Combined with daily change rate, determines total backup storage needed.",
-    "dailyChangeRate": "Percentage of data that changes each day. Higher change rates mean larger incremental backups and more storage consumption over the retention period."
+    "dailyChangeRate": "Percentage of data that changes each day. Higher change rates mean larger incremental backups and more storage consumption over the retention period.",
+    "performanceThreshold": "Performance threshold limits how full the storage can be before degradation. Most storage systems slow down as they approach capacity. Setting 85% means only 85% of usable capacity is shown as the operational limit. Default 100% (no limit)."
   },
   "output": {
     "rawCapacity": "Total physical capacity of all drives before any overhead. Calculated as: drive capacity x drive count x server count.",

--- a/src/i18n/locales/en/output.json
+++ b/src/i18n/locales/en/output.json
@@ -4,6 +4,7 @@
     "raw": "Raw Capacity",
     "usable": "Usable Capacity",
     "effective": "Effective Capacity",
+    "operationalLimit": "Operational Limit",
     "afterCompression": "After compression",
     "efficiency": "Efficiency",
     "zfsBreakdown": "ZFS Capacity Breakdown",

--- a/src/i18n/locales/fr/advanced.json
+++ b/src/i18n/locales/fr/advanced.json
@@ -56,5 +56,10 @@
     "reflinkHint": "Clones copy-on-write pour sauvegardes efficaces",
     "backupRetention": "Retention sauvegarde (Jours)",
     "dailyChangeRate": "Taux de changement journalier (%)"
+  },
+  "capacityManagement": {
+    "title": "Gestion de la capacite",
+    "performanceThreshold": "Seuil de performance",
+    "performanceThresholdHint": "Limiter la capacite operationnelle pour maintenir les performances (defaut 100%)"
   }
 }

--- a/src/i18n/locales/fr/help.json
+++ b/src/i18n/locales/fr/help.json
@@ -29,7 +29,8 @@
     "fsType": "Le choix du systeme de fichiers affecte la surcharge et les fonctionnalites. ZFS a environ 3 % de surcharge (slop space). XFS/ReFS prennent en charge les reflinks pour des snapshots efficaces. Btrfs prend en charge les snapshots avec environ 4 % de surcharge.",
     "controller": "Le controleur de stockage ou HBA limite le total des IOPS et du debit. Le RAID logiciel utilise le processeur pour les calculs de parite. Les controleurs RAID materiels ont des plafonds d'IOPS et de debit fixes.",
     "backupRetention": "Nombre de jours de conservation des copies de sauvegarde. Combine au taux de modification quotidien, il determine le stockage de sauvegarde total necessaire.",
-    "dailyChangeRate": "Pourcentage des donnees modifiees chaque jour. Un taux de modification plus eleve signifie des sauvegardes incrementales plus volumineuses et une consommation de stockage accrue sur la periode de retention."
+    "dailyChangeRate": "Pourcentage des donnees modifiees chaque jour. Un taux de modification plus eleve signifie des sauvegardes incrementales plus volumineuses et une consommation de stockage accrue sur la periode de retention.",
+    "performanceThreshold": "Le seuil de performance limite le taux de remplissage du stockage avant degradation. La plupart des systemes de stockage ralentissent a mesure qu'ils approchent de leur capacite. Fixer 85% signifie que seuls 85% de la capacite utilisable sont affiches comme limite operationnelle. Par defaut 100% (pas de limite)."
   },
   "output": {
     "rawCapacity": "Capacite physique totale de tous les disques avant toute surcharge. Calculee comme suit : capacite du disque x nombre de disques x nombre de serveurs.",

--- a/src/i18n/locales/fr/output.json
+++ b/src/i18n/locales/fr/output.json
@@ -4,6 +4,7 @@
     "raw": "Capacité brute",
     "usable": "Capacité utilisable",
     "effective": "Capacité effective",
+    "operationalLimit": "Limite opérationnelle",
     "afterCompression": "Après compression",
     "efficiency": "Efficacité",
     "zfsBreakdown": "Répartition capacité ZFS",

--- a/src/i18n/locales/it/advanced.json
+++ b/src/i18n/locales/it/advanced.json
@@ -56,5 +56,10 @@
     "reflinkHint": "Cloni copy-on-write per backup efficienti",
     "backupRetention": "Retention backup (Giorni)",
     "dailyChangeRate": "Tasso cambio giornaliero (%)"
+  },
+  "capacityManagement": {
+    "title": "Gestione capacita",
+    "performanceThreshold": "Soglia prestazioni",
+    "performanceThresholdHint": "Limitare la capacita operativa per mantenere le prestazioni (default 100%)"
   }
 }

--- a/src/i18n/locales/it/help.json
+++ b/src/i18n/locales/it/help.json
@@ -29,7 +29,8 @@
     "fsType": "La scelta del filesystem influisce sull'overhead e sulle funzionalità. ZFS ha un overhead di ~3% per lo slop space. XFS/ReFS supportano i reflink per snapshot efficienti. Btrfs supporta gli snapshot con un overhead di ~4%.",
     "controller": "Il controller di storage o HBA limita il totale di IOPS e throughput. Il RAID software utilizza la CPU per i calcoli di parità. I controller RAID hardware hanno limiti fissi di IOPS/throughput.",
     "backupRetention": "Numero di giorni di conservazione delle copie di backup. Combinato con il tasso di variazione giornaliero, determina lo storage totale necessario per i backup.",
-    "dailyChangeRate": "Percentuale di dati che cambia ogni giorno. Tassi di variazione più elevati comportano backup incrementali più grandi e un maggiore consumo di storage nel periodo di conservazione."
+    "dailyChangeRate": "Percentuale di dati che cambia ogni giorno. Tassi di variazione più elevati comportano backup incrementali più grandi e un maggiore consumo di storage nel periodo di conservazione.",
+    "performanceThreshold": "La soglia di prestazioni limita quanto può essere pieno lo storage prima del degrado. La maggior parte dei sistemi di storage rallenta man mano che si avvicina alla capacità massima. Impostando l'85% significa che solo l'85% della capacità utilizzabile viene mostrato come limite operativo. Default 100% (nessun limite)."
   },
   "output": {
     "rawCapacity": "Capacità fisica totale di tutti i dischi prima di qualsiasi overhead. Calcolata come: capacità del disco x numero di dischi x numero di server.",

--- a/src/i18n/locales/it/output.json
+++ b/src/i18n/locales/it/output.json
@@ -4,6 +4,7 @@
     "raw": "Capacità grezza",
     "usable": "Capacità utilizzabile",
     "effective": "Capacità effettiva",
+    "operationalLimit": "Limite operativo",
     "afterCompression": "Dopo compressione",
     "efficiency": "Efficienza",
     "zfsBreakdown": "Ripartizione capacità ZFS",

--- a/src/store/slices/advancedSlice.ts
+++ b/src/store/slices/advancedSlice.ts
@@ -24,6 +24,7 @@ export interface AdvancedSlice extends AdvancedState, FilesystemState {
   setProjectYears: (years: number) => void
   setElectricityCost: (cost: number) => void
   setUnitSystem: (system: 'binary' | 'decimal') => void
+  setPerformanceThreshold: (threshold: number) => void
 
   // Filesystem actions
   setFsType: (type: FilesystemState['fsType']) => void
@@ -44,6 +45,7 @@ export const createAdvancedSlice: StateCreator<AdvancedSlice> = (set) => ({
   projectYears: 5,
   electricityCostPerKwh: 0.12,
   unitSystem: 'binary', // Default to binary (TiB/GiB) - more accurate for storage
+  performanceThreshold: 1.0, // Default 100% = no limit
 
   // Default filesystem state
   fsType: 'zfs',
@@ -64,6 +66,8 @@ export const createAdvancedSlice: StateCreator<AdvancedSlice> = (set) => ({
   setElectricityCost: (electricityCostPerKwh) =>
     set({ electricityCostPerKwh: Math.max(0, electricityCostPerKwh) }),
   setUnitSystem: (unitSystem) => set({ unitSystem }),
+  setPerformanceThreshold: (performanceThreshold) =>
+    set({ performanceThreshold: Math.min(1.0, Math.max(0.5, performanceThreshold)) }),
 
   // Filesystem actions
   setFsType: (fsType) => set({ fsType }),

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -129,6 +129,8 @@ export interface AdvancedState {
   electricityCostPerKwh: number
   /** Unit system for display: binary (TiB/GiB) or decimal (TB/GB) */
   unitSystem: 'binary' | 'decimal'
+  /** Performance threshold for display (0.5-1.0, default 1.0 = 100% = no limit) */
+  performanceThreshold: number
 }
 
 /** File system options for backup calculations */


### PR DESCRIPTION
## Summary

Implements GitHub issue #5: User-Defined Performance Capacity Thresholds

- Adds a global "Performance Threshold" slider (50-100%, default 100%) in Advanced settings
- When threshold < 100%, displays an "Operational Limit" metric showing recommended capacity
- Pure display feature - does not modify engine calculations
- Works with all topology types (RAID, ZFS, vSAN, Ceph, S2D, etc.)

## Changes

- `src/types/config.ts` - Add `performanceThreshold` to AdvancedState
- `src/store/slices/advancedSlice.ts` - Add state and setter with 0.5-1.0 clamping
- `src/components/inputs/AdvancedPanel.tsx` - Add "Capacity Management" section with slider
- `src/components/layout/OutputDashboard.tsx` - Show "Operational Limit" when threshold active
- `src/i18n/locales/{en,fr,de,it}/` - Add translations for all 4 languages

## Test plan

- [ ] Set threshold to 100% (default) → no "Operational Limit" shown
- [ ] Set threshold to 85% → shows both "Usable Capacity" and "Operational Limit @ 85%"
- [ ] Verify works with multiple topologies (RAID5, ZFS, vSAN, Ceph)
- [ ] Verify URL sharing preserves threshold setting
- [ ] Run `npm run typecheck && npm run lint && npm test`

Closes #5

🤖 Generated with [Claude Code](https://claude.ai/code)