### PR TITLE
fix(security): update jspdf to 4.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "raidy",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "raidy",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "d3-sankey": "^0.12.3",
         "dompurify": "^3.3.1",
         "i18next": "^25.7.4",
         "i18next-browser-languagedetector": "^8.2.0",
         "js-yaml": "^4.1.1",
-        "jspdf": "^4.0.0",
+        "jspdf": "^4.1.0",
         "jspdf-autotable": "^5.0.7",
         "lz-string": "^1.5.0",
         "react": "^19.2.0",
@@ -3772,9 +3772,9 @@
       }
     },
     "node_modules/jspdf": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.0.0.tgz",
-      "integrity": "sha512-w12U97Z6edKd2tXDn3LzTLg7C7QLJlx0BPfM3ecjK2BckUl9/81vZ+r5gK4/3KQdhAcEZhENUxRhtgYBj75MqQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.1.0.tgz",
+      "integrity": "sha512-xd1d/XRkwqnsq6FP3zH1Q+Ejqn2ULIJeDZ+FTKpaabVpZREjsJKRJwuokTNgdqOU+fl55KgbvgZ1pRTSWCP2kQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
@@ -3784,7 +3784,7 @@
       "optionalDependencies": {
         "canvg": "^3.0.11",
         "core-js": "^3.6.0",
-        "dompurify": "^3.2.4",
+        "dompurify": "^3.3.1",
         "html2canvas": "^1.0.0-rc.5"
       }
     },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "i18next": "^25.7.4",
     "i18next-browser-languagedetector": "^8.2.0",
     "js-yaml": "^4.1.1",
-    "jspdf": "^4.0.0",
+    "jspdf": "^4.1.0",
     "jspdf-autotable": "^5.0.7",
     "lz-string": "^1.5.0",
     "react": "^19.2.0",


### PR DESCRIPTION
## Summary

Updates jspdf from 4.0.0 to 4.1.0 to fix 4 Dependabot security alerts.

## Security fixes

| Severity | Issue |
|----------|-------|
| **High** | PDF Injection allowing arbitrary JS execution |
| **High** | DoS via unvalidated BMP dimensions |
| Medium | XMP Metadata Injection |
| Medium | Shared State Race Condition |

## Verification

- `npm audit` shows 0 vulnerabilities
- All 613 tests pass
- TypeScript and lint checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)