### PR TITLE
feat(volumetry): connect filesystem selector to capacity calculations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "snyk.advanced.autoSelectOrganization": true
+}

--- a/src/engines/volumetry/index.ts
+++ b/src/engines/volumetry/index.ts
@@ -61,6 +61,7 @@ export interface VolumetryInput {
   powervaultOptions: PowerVaultOptions
   compressionRatio: number
   dedupRatio: number
+  fsType: 'xfs' | 'ext4' | 'zfs' | 'refs' | 'ntfs' | 'btrfs'
 }
 
 /**
@@ -92,6 +93,7 @@ export function calculateVolumetry(input: VolumetryInput): VolumetryResult {
     nutanixOptions,
     compressionRatio,
     dedupRatio,
+    fsType,
   } = input
 
   // Validate topology
@@ -173,6 +175,7 @@ export function calculateVolumetry(input: VolumetryInput): VolumetryResult {
     powerstoreOptions,
     powerscaleOptions,
     cephOptions,
+    fsType,
   })
 
   // Extract overhead values

--- a/src/engines/volumetry/overhead/filesystem-overhead.ts
+++ b/src/engines/volumetry/overhead/filesystem-overhead.ts
@@ -17,33 +17,40 @@
 import type { NetAppOptions, SynologyOptions, Topology } from '@/types/topology'
 import { FILESYSTEM_OVERHEAD } from '@/types/topology'
 
+/** Filesystem type for user selection */
+type FsType = 'xfs' | 'ext4' | 'zfs' | 'refs' | 'ntfs' | 'btrfs'
+
 /**
  * Get filesystem overhead percentage for topology.
  *
  * Returns the decimal overhead percentage (e.g., 0.015 = 1.5%).
  *
  * @param topology - Storage topology configuration
+ * @param fsType - User-selected filesystem type (used for standard RAID)
  * @param synologyOptions - Synology-specific options (filesystem type)
  * @param netAppOptions - NetApp-specific options (WAFL overhead)
  * @returns Overhead percentage as decimal (0-1)
  *
  * @example
- * // ZFS topology
+ * // Standard RAID with XFS
  * const overhead = getFilesystemOverheadPercent(
- *   { type: 'zfs', level: 'raidz2' }
+ *   { type: 'standard', level: 'raid5' },
+ *   'xfs'
  * )
- * // Returns: 0.01 (1% metadata overhead)
+ * // Returns: 0.01 (1% XFS overhead)
  *
  * @example
  * // Synology with Btrfs
  * const overhead = getFilesystemOverheadPercent(
  *   { type: 'proprietary', level: 'synology_shr2' },
+ *   'ext4',
  *   { filesystem: 'btrfs' }
  * )
  * // Returns: 0.04 (4% Btrfs overhead)
  */
 export function getFilesystemOverheadPercent(
   topology: Topology,
+  fsType: FsType,
   synologyOptions?: SynologyOptions,
   netAppOptions?: NetAppOptions,
 ): number {
@@ -89,6 +96,10 @@ export function getFilesystemOverheadPercent(
       // PowerVault ME5: minimal metadata overhead (~1%)
       return 0.01
 
+    case 'standard':
+      // Standard RAID: use user-selected filesystem overhead
+      return getFsTypeOverhead(fsType)
+
     case 'proprietary':
       // Check for Synology or NetApp based on topology level
       if (topology.level.startsWith('synology_') && synologyOptions) {
@@ -104,7 +115,29 @@ export function getFilesystemOverheadPercent(
       return 0.02
 
     default:
-      // ext4/XFS typically use 1-3% for metadata
-      return 0.02
+      // For other topologies, use user-selected filesystem overhead
+      return getFsTypeOverhead(fsType)
+  }
+}
+
+/**
+ * Get overhead percentage for a specific filesystem type.
+ */
+function getFsTypeOverhead(fsType: FsType): number {
+  switch (fsType) {
+    case 'xfs':
+      return FILESYSTEM_OVERHEAD.xfs
+    case 'ext4':
+      return FILESYSTEM_OVERHEAD.ext4
+    case 'zfs':
+      return FILESYSTEM_OVERHEAD.zfs
+    case 'btrfs':
+      return FILESYSTEM_OVERHEAD.btrfs
+    case 'refs':
+      return FILESYSTEM_OVERHEAD.refs
+    case 'ntfs':
+      return FILESYSTEM_OVERHEAD.ntfs
+    default:
+      return 0.02 // Fallback
   }
 }

--- a/src/engines/volumetry/overhead/overheadCalculator.ts
+++ b/src/engines/volumetry/overhead/overheadCalculator.ts
@@ -71,6 +71,7 @@ export interface OverheadInput {
   powerstoreOptions: PowerStoreOptions
   powerscaleOptions: PowerScaleOptions
   cephOptions: CephOptions
+  fsType: 'xfs' | 'ext4' | 'zfs' | 'refs' | 'ntfs' | 'btrfs'
 }
 
 /**
@@ -96,6 +97,7 @@ export function calculateOverheads(input: OverheadInput): OverheadResult {
     powerstoreOptions,
     powerscaleOptions,
     cephOptions,
+    fsType,
   } = input
 
   // Synology system partition overhead (20-30GB per disk)
@@ -174,7 +176,12 @@ export function calculateOverheads(input: OverheadInput): OverheadResult {
   }
 
   // Filesystem overhead
-  const fsOverheadPercent = getFilesystemOverheadPercent(topology, synologyOptions, netAppOptions)
+  const fsOverheadPercent = getFilesystemOverheadPercent(
+    topology,
+    fsType,
+    synologyOptions,
+    netAppOptions,
+  )
   const capacityForFs =
     capacityAfterParity -
     slopOverhead -

--- a/src/hooks/useVolumetryCalc.ts
+++ b/src/hooks/useVolumetryCalc.ts
@@ -41,6 +41,8 @@ export function useVolumetryCalc(): VolumetryResult {
     // Advanced (capacity modifiers only)
     compressionRatio,
     dedupRatio,
+    // Filesystem type for overhead calculation
+    fsType,
   } = useConfigStore()
 
   // Get selected drive
@@ -87,6 +89,7 @@ export function useVolumetryCalc(): VolumetryResult {
         powervaultOptions,
         compressionRatio,
         dedupRatio,
+        fsType,
       })
     } catch (error) {
       console.error('[Volumetry Engine Error]', {
@@ -135,5 +138,6 @@ export function useVolumetryCalc(): VolumetryResult {
     powervaultOptions,
     compressionRatio,
     dedupRatio,
+    fsType,
   ])
 }

--- a/src/types/topology.ts
+++ b/src/types/topology.ts
@@ -633,12 +633,14 @@ export const DEFAULT_NETAPP_OPTIONS: NetAppOptions = {
 
 /** Filesystem overhead constants */
 export const FILESYSTEM_OVERHEAD = {
-  btrfs: 0.04, // 4% for Btrfs metadata
-  ext4: 0.02, // 2% for ext4
-  xfs: 0.02, // 2% for XFS
+  btrfs: 0.04, // 4% for Btrfs metadata + CoW
+  ext4: 0.05, // 5% for ext4 (default root reservation)
+  xfs: 0.01, // 1% for XFS (minimal metadata)
+  zfs: 0.01, // 1% for ZFS metadata (slop handled separately)
   zfs_slop: 1 / 64, // 1.5625% ZFS slop space
   wafl: 0.015, // 1.5% WAFL default
-  refs: 0.02, // 2% for ReFS
+  refs: 0.02, // 2% for ReFS (integrity streams)
+  ntfs: 0.02, // 2% for NTFS (MFT reservation)
 } as const
 
 /** Controller/HBA performance limits (IOPS, throughput in MB/s) */


### PR DESCRIPTION
## Summary

Wires the fsType setting from Advanced panel to the volumetry engine so different filesystems show accurate overhead percentages.

## Filesystem overhead values

| Filesystem | Overhead | Notes |
|------------|----------|-------|
| XFS | 1% | Minimal metadata |
| ext4 | 5% | Default root reservation |
| ZFS | 1% | Metadata (slop handled separately) |
| Btrfs | 4% | CoW + metadata |
| ReFS | 2% | Integrity streams |
| NTFS | 2% | MFT reservation |

Closes #6

🤖 Generated with [Claude Code](https://claude.ai/code)