### PR TITLE
fix(security): resolve CodeQL alerts in anonymize-drives script

### DIFF
--- a/scripts/anonymize-drives.mjs
+++ b/scripts/anonymize-drives.mjs
@@ -132,7 +132,7 @@ function buildId(tier, type, rpm, iface, capacity, extras) {
   else if (rpm === 7200) rpmStr = '7k2'
   else if (rpm && rpm < 7200) rpmStr = '5k4'
 
-  const ifaceStr = iface.toLowerCase().replace('pcie', 'pcie')
+  const ifaceStr = iface.toLowerCase()
 
   // Format capacity
   let capStr
@@ -286,7 +286,7 @@ for (const [key, members] of groups) {
     } else {
       if (nand) idExtras = nand.toLowerCase()
       if (ff && !['2.5"', '3.5"'].includes(ff)) {
-        idExtras += (idExtras ? '-' : '') + ff.toLowerCase().replace('.', '').replace('"', '')
+        idExtras += (idExtras ? '-' : '') + ff.toLowerCase().replaceAll('.', '').replaceAll('"', '')
       }
       if (workload === 'ri') idExtras += '-ri'
       else if (workload === 'mu') idExtras += '-mu'


### PR DESCRIPTION
## Summary

- Remove no-op `replace('pcie', 'pcie')` — replacement of substring with itself (medium)
- Use `replaceAll()` instead of `replace()` for complete string escaping (high)

Fixes CodeQL alerts #1 and #2.

## Test plan

- [x] Script is a standalone build tool, not runtime code — no test regression possible
- [ ] CodeQL re-scan shows 0 alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved string sanitization to remove all special characters from drive identifiers, ensuring more accurate processing.

* **Refactor**
  * Streamlined internal drive ID generation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->