### PR TITLE
Single-slide PPTX export (v1.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2026-05-24
+
+### Changed
+- PowerPoint export is now a single executive one-pager instead of a 7-slide deck. The slide keeps all visuals — Sankey capacity waterfall, performance speedometers, and resilience donut — alongside a compact key-metrics grid (usable capacity, efficiency, IOPS, power, energy, CO₂, survival) and a bottleneck footer.
+
 ## [1.6.0] - 2026-05-24
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raidy",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.6.1",
   "type": "module",
   "description": "Browser-based simulator for modern storage infrastructure (RAID, ZFS, vSAN, S2D, Nutanix, Dell, NetApp, Ceph, Synology). 100% client-side.",
   "scripts": {

--- a/src/components/layout/OutputDashboard.tsx
+++ b/src/components/layout/OutputDashboard.tsx
@@ -376,8 +376,9 @@ export function OutputDashboard() {
           </h3>
 
           {/* Responsive speedometer grid */}
-          <div id="speedometer-chart" className="grid grid-cols-2 gap-2 sm:gap-4">
+          <div className="grid grid-cols-2 gap-2 sm:gap-4">
             <Speedometer
+              id="gauge-read-mbps"
               value={performance.maxReadThroughputMBs}
               max={50000}
               label={t('performance.read')}
@@ -385,6 +386,7 @@ export function OutputDashboard() {
               size={isMobile ? 100 : 140}
             />
             <Speedometer
+              id="gauge-write-mbps"
               value={performance.maxWriteThroughputMBs}
               max={50000}
               label={t('performance.write')}
@@ -392,6 +394,7 @@ export function OutputDashboard() {
               size={isMobile ? 100 : 140}
             />
             <Speedometer
+              id="gauge-read-iops"
               value={performance.maxReadIOPS}
               max={2000000}
               label={t('performance.readIops')}
@@ -404,6 +407,7 @@ export function OutputDashboard() {
               ]}
             />
             <Speedometer
+              id="gauge-write-iops"
               value={performance.maxWriteIOPS}
               max={2000000}
               label={t('performance.writeIops')}

--- a/src/components/layout/OutputDashboard.tsx
+++ b/src/components/layout/OutputDashboard.tsx
@@ -376,7 +376,7 @@ export function OutputDashboard() {
           </h3>
 
           {/* Responsive speedometer grid */}
-          <div className="grid grid-cols-2 gap-2 sm:gap-4">
+          <div id="speedometer-chart" className="grid grid-cols-2 gap-2 sm:gap-4">
             <Speedometer
               value={performance.maxReadThroughputMBs}
               max={50000}

--- a/src/components/outputs/Speedometer.tsx
+++ b/src/components/outputs/Speedometer.tsx
@@ -12,6 +12,8 @@ interface SpeedometerProps {
   unit: string
   size?: number
   thresholds?: { value: number; color: string }[]
+  /** Optional DOM id (used to capture an individual gauge for PPTX export). */
+  id?: string
 }
 
 // Default color thresholds (percentage of max)
@@ -28,6 +30,7 @@ export function Speedometer({
   unit,
   size = 180,
   thresholds = DEFAULT_THRESHOLDS,
+  id,
 }: SpeedometerProps) {
   const { angle, color, formattedValue } = useMemo(() => {
     const percent = Math.min(value / max, 1)
@@ -136,7 +139,7 @@ export function Speedometer({
   }, [center, innerRadius, strokeWidth])
 
   return (
-    <div className="flex flex-col items-center">
+    <div id={id} className="flex flex-col items-center">
       <svg
         width={size}
         height={size * 0.7}

--- a/src/components/outputs/Speedometer.tsx
+++ b/src/components/outputs/Speedometer.tsx
@@ -136,7 +136,7 @@ export function Speedometer({
   }, [center, innerRadius, strokeWidth])
 
   return (
-    <div id="speedometer-chart" className="flex flex-col items-center">
+    <div className="flex flex-col items-center">
       <svg
         width={size}
         height={size * 0.7}

--- a/src/i18n/locales/de/output.json
+++ b/src/i18n/locales/de/output.json
@@ -143,6 +143,8 @@
     "performance": "Leistung",
     "resilience": "Ausfallsicherheit",
     "sustainability": "Nachhaltigkeit",
+    "backup": "Backup",
+    "bottleneck": "Engpässe",
     "bom": "Stückliste"
   }
 }

--- a/src/i18n/locales/en/output.json
+++ b/src/i18n/locales/en/output.json
@@ -143,6 +143,8 @@
     "performance": "Performance",
     "resilience": "Resilience",
     "sustainability": "Sustainability",
+    "backup": "Backup",
+    "bottleneck": "Bottlenecks",
     "bom": "Bill of Materials"
   }
 }

--- a/src/i18n/locales/fr/output.json
+++ b/src/i18n/locales/fr/output.json
@@ -143,6 +143,8 @@
     "performance": "Performance",
     "resilience": "Résilience",
     "sustainability": "Durabilité",
+    "backup": "Sauvegarde",
+    "bottleneck": "Goulots d'étranglement",
     "bom": "Nomenclature"
   }
 }

--- a/src/i18n/locales/it/output.json
+++ b/src/i18n/locales/it/output.json
@@ -143,6 +143,8 @@
     "performance": "Prestazioni",
     "resilience": "Resilienza",
     "sustainability": "Sostenibilità",
+    "backup": "Backup",
+    "bottleneck": "Colli di bottiglia",
     "bom": "Distinta Materiali"
   }
 }

--- a/src/utils/captureChart.ts
+++ b/src/utils/captureChart.ts
@@ -4,41 +4,36 @@
  */
 import { toPng } from 'html-to-image'
 
+const PNG_OPTIONS = { backgroundColor: '#1A1B2E', pixelRatio: 2 } as const
+
+/** Rasterize a DOM element (by id) to a PNG data URL, or null if not mounted. */
+async function captureById(id: string): Promise<string | null> {
+  const el = document.getElementById(id)
+  if (!el) return null
+  return toPng(el, PNG_OPTIONS)
+}
+
 /**
  * Capture the Sankey diagram as a PNG data URL.
  * Returns null if the element is not mounted in the DOM (e.g. collapsed panel).
  */
-export async function captureSankeyDiagram(): Promise<string | null> {
-  const el = document.getElementById('sankey-diagram')
-  if (!el) return null
-  return toPng(el, {
-    backgroundColor: '#1A1B2E',
-    pixelRatio: 2,
-  })
+export function captureSankeyDiagram(): Promise<string | null> {
+  return captureById('sankey-diagram')
 }
 
-/**
- * Capture the performance speedometer as a PNG data URL.
- * Returns null if the element is not mounted in the DOM.
- */
-export async function captureSpeedometer(): Promise<string | null> {
-  const el = document.getElementById('speedometer-chart')
-  if (!el) return null
-  return toPng(el, {
-    backgroundColor: '#1A1B2E',
-    pixelRatio: 2,
-  })
-}
+/** Ids of the four performance gauges, in display order (R/W MB/s, R/W IOPS). */
+export const GAUGE_IDS = [
+  'gauge-read-mbps',
+  'gauge-write-mbps',
+  'gauge-read-iops',
+  'gauge-write-iops',
+] as const
 
 /**
- * Capture the resilience donut chart as a PNG data URL.
- * Returns null if the element is not mounted in the DOM.
+ * Capture the four performance gauges individually so they can be laid out in a
+ * tight grid in the export (the dashboard's responsive grid spreads them apart).
+ * Returns one data URL (or null) per gauge, in GAUGE_IDS order.
  */
-export async function captureDonutChart(): Promise<string | null> {
-  const el = document.getElementById('donut-chart')
-  if (!el) return null
-  return toPng(el, {
-    backgroundColor: '#1A1B2E',
-    pixelRatio: 2,
-  })
+export function capturePerfGauges(): Promise<(string | null)[]> {
+  return Promise.all(GAUGE_IDS.map(captureById))
 }

--- a/src/utils/exportPptx.ts
+++ b/src/utils/exportPptx.ts
@@ -1,7 +1,9 @@
 /**
  * PPTX Export utility using pptxgenjs.
- * Generates an in-browser presentation with dark brand styling.
- * No server requests — pptxgenjs runs entirely client-side.
+ * Generates a single-slide, in-browser executive one-pager with the Sankey,
+ * speedometers, and resilience donut plus a compact metric grid. Charts are
+ * captured from the DOM via html-to-image. No server requests — pptxgenjs runs
+ * entirely client-side.
  */
 import pptxgen from 'pptxgenjs'
 
@@ -48,7 +50,7 @@ function formatIops(iops: number): string {
   return iops.toFixed(0)
 }
 
-/** Add the thin accent bar at the top of every slide. */
+/** Add the thin accent bar at the top of the slide. */
 function addAccentBar(slide: pptxgen.Slide, prs: pptxgen): void {
   slide.addShape(prs.ShapeType.rect, {
     x: 0,
@@ -60,545 +62,244 @@ function addAccentBar(slide: pptxgen.Slide, prs: pptxgen): void {
   })
 }
 
-/** Add a slide heading at the standard position. */
-function addSlideHeading(slide: pptxgen.Slide, title: string): void {
-  slide.addText(title, {
-    x: 0.4,
-    y: 0.2,
-    w: 12.5,
-    h: 0.5,
-    fontSize: 22,
+/** A small uppercase section label. */
+function addSectionLabel(
+  slide: pptxgen.Slide,
+  title: string,
+  color: string,
+  x: number,
+  y: number,
+): void {
+  slide.addText(title.toUpperCase(), {
+    x,
+    y,
+    w: 6.0,
+    h: 0.3,
+    fontSize: 12,
     bold: true,
-    color: BRAND.textWhite,
+    color,
+    charSpacing: 1,
     fontFace: 'Calibri',
   })
 }
 
-/** Add a stacked label+value metric block. */
-function addMetricBlock(
+/** Place a captured chart image (aspect-preserving), or a muted fallback note. */
+function addChartOrFallback(
+  slide: pptxgen.Slide,
+  dataUrl: string | null,
+  box: { x: number; y: number; w: number; h: number },
+  fallback: string,
+): void {
+  if (dataUrl) {
+    slide.addImage({ data: dataUrl, sizing: { type: 'contain', w: box.w, h: box.h }, ...box })
+  } else {
+    slide.addText(fallback, {
+      x: box.x,
+      y: box.y + box.h / 2 - 0.25,
+      w: box.w,
+      h: 0.5,
+      fontSize: 12,
+      color: BRAND.textMuted,
+      italic: true,
+      fontFace: 'Calibri',
+      align: 'center',
+    })
+  }
+}
+
+/** A compact label-over-value metric for the bottom grid. */
+function addCompactMetric(
   slide: pptxgen.Slide,
   label: string,
   value: string,
   color: string,
   x: number,
   y: number,
-  w = 3.5,
 ): void {
   slide.addText(label, {
     x,
     y,
-    w,
-    h: 0.35,
-    fontSize: 13,
+    w: 2.3,
+    h: 0.26,
+    fontSize: 10,
     color: BRAND.textMuted,
     fontFace: 'Calibri',
   })
   slide.addText(value, {
     x,
-    y: y + 0.38,
-    w,
-    h: 0.6,
-    fontSize: 20,
+    y: y + 0.28,
+    w: 2.3,
+    h: 0.4,
+    fontSize: 15,
     bold: true,
     color,
     fontFace: 'Calibri',
   })
 }
 
-/** Build the title slide (Slide 1). */
-function buildTitleSlide(prs: pptxgen, config: ExportConfig): void {
+/** Build the single executive one-pager slide (charts + metric grid). */
+function buildSummarySlide(
+  prs: pptxgen,
+  config: ExportConfig,
+  charts: { sankey: string | null; speedometer: string | null; donut: string | null },
+): void {
   const slide = prs.addSlide()
   slide.background = { fill: BRAND.bg }
   addAccentBar(slide, prs)
 
+  const { volumetry: vol, performance: perf, resilience, sustainability: sus } = config.results
+
+  // ── Header ────────────────────────────────────────────────────────────
   const topologyLabel = config.topology.type.toUpperCase()
   const levelLabel = 'level' in config.topology ? ` ${config.topology.level}` : ''
-  const title = `${topologyLabel}${levelLabel}`
-  const driveLabel = config.drive.model
+  slide.addText(`${topologyLabel}${levelLabel}`, {
+    x: 0.4,
+    y: 0.16,
+    w: 9.0,
+    h: 0.5,
+    fontSize: 20,
+    bold: true,
+    color: BRAND.textWhite,
+    fontFace: 'Calibri',
+  })
+
   const date = new Date().toLocaleDateString(i18n.language, {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
   })
-
-  // Main title
-  slide.addText(title, {
-    x: 1,
-    y: 2.2,
-    w: 11.33,
-    h: 1.2,
-    fontSize: 48,
-    bold: true,
-    color: BRAND.textWhite,
-    fontFace: 'Calibri',
-    align: 'center',
-  })
-
-  // Subtitle — drive model
-  slide.addText(driveLabel, {
-    x: 1,
-    y: 3.5,
-    w: 11.33,
-    h: 0.7,
-    fontSize: 24,
-    color: BRAND.textMuted,
-    fontFace: 'Calibri',
-    align: 'center',
-  })
-
-  // Footer — date
-  slide.addText(date, {
-    x: 1,
-    y: 6.8,
-    w: 11.33,
-    h: 0.4,
-    fontSize: 12,
-    color: BRAND.textMuted,
-    fontFace: 'Calibri',
-    align: 'center',
-  })
-}
-
-/** Build the executive summary slide (Slide 2). */
-function buildExecutiveSummarySlide(prs: pptxgen, config: ExportConfig): void {
-  const slide = prs.addSlide()
-  slide.background = { fill: BRAND.bg }
-  addAccentBar(slide, prs)
-  addSlideHeading(slide, i18n.t('output:pptx.executiveSummary'))
-
-  const vol = config.results.volumetry
-  const perf = config.results.performance
-  const resilience = config.results.resilience
-  const sus = config.results.sustainability
-
-  // Topology label row
-  const topologyLabel = config.topology.type.toUpperCase()
-  const levelLabel = 'level' in config.topology ? ` ${config.topology.level}` : ''
-  slide.addText(`${topologyLabel}${levelLabel}`, {
+  const serverCount =
+    'serverCount' in config.topology
+      ? String((config.topology as { serverCount: number }).serverCount)
+      : null
+  const subParts = [
+    config.drive.model,
+    `${config.driveCount} drives`,
+    serverCount ? `${serverCount} servers` : null,
+    date,
+  ].filter(Boolean)
+  slide.addText(subParts.join('  ·  '), {
     x: 0.4,
-    y: 0.9,
+    y: 0.68,
     w: 12.5,
-    h: 0.5,
-    fontSize: 16,
-    bold: true,
-    color: BRAND.accent,
+    h: 0.28,
+    fontSize: 10.5,
+    color: BRAND.textMuted,
     fontFace: 'Calibri',
   })
 
-  // 3-column × 2-row metric grid
-  const cols: [number, number, number] = [0.4, 4.6, 9.0]
-  const rows: [number, number] = [1.5, 3.6]
+  // ── Top row: Sankey (capacity) + Speedometers (performance) ───────────
+  addSectionLabel(slide, i18n.t('output:pptx.volumetry'), BRAND.capacity, 0.35, 1.0)
+  addChartOrFallback(
+    slide,
+    charts.sankey,
+    { x: 0.35, y: 1.32, w: 6.7, h: 2.7 },
+    'Capacity chart unavailable',
+  )
 
-  addMetricBlock(
+  addSectionLabel(slide, i18n.t('output:pptx.performance'), BRAND.accent, 7.2, 1.0)
+  addChartOrFallback(
+    slide,
+    charts.speedometer,
+    { x: 7.2, y: 1.32, w: 5.8, h: 2.7 },
+    'Performance chart unavailable',
+  )
+
+  // ── Bottom row: Resilience donut + key-metric grid ────────────────────
+  addSectionLabel(slide, i18n.t('output:pptx.resilience'), BRAND.capacity, 0.35, 4.1)
+  addChartOrFallback(
+    slide,
+    charts.donut,
+    { x: 0.35, y: 4.4, w: 2.9, h: 2.5 },
+    'Resilience simulation not run',
+  )
+
+  addSectionLabel(slide, i18n.t('output:pptx.executiveSummary'), BRAND.textMuted, 3.7, 4.1)
+  const mcolX: [number, number, number, number] = [3.7, 6.05, 8.4, 10.75]
+  const mrowY: [number, number] = [4.45, 5.7]
+  // Row 1
+  addCompactMetric(
     slide,
     'Usable Capacity',
     `${bytesToTB(vol.usableCapacity).toFixed(1)} TB`,
     BRAND.capacity,
-    cols[0],
-    rows[0],
-    4.0,
+    mcolX[0],
+    mrowY[0],
   )
-  addMetricBlock(
+  addCompactMetric(
+    slide,
+    'Efficiency',
+    `${vol.efficiency.toFixed(1)}%`,
+    BRAND.overhead,
+    mcolX[1],
+    mrowY[0],
+  )
+  addCompactMetric(
     slide,
     'Read IOPS',
     formatIops(perf.maxReadIOPS),
     BRAND.accent,
-    cols[1],
-    rows[0],
-    4.0,
+    mcolX[2],
+    mrowY[0],
   )
-  addMetricBlock(
+  addCompactMetric(
     slide,
     'Write IOPS',
     formatIops(perf.maxWriteIOPS),
     BRAND.accent,
-    cols[2],
-    rows[0],
-    4.0,
+    mcolX[3],
+    mrowY[0],
   )
-  addMetricBlock(
-    slide,
-    'Resilience',
-    resilience ? `${resilience.survivalPercent} (${resilience.nines} nines)` : 'N/A',
-    BRAND.capacity,
-    cols[0],
-    rows[1],
-    4.0,
-  )
-  addMetricBlock(
-    slide,
-    'Annual Energy',
-    `${sus.annualEnergyKwh.toFixed(0)} kWh`,
-    BRAND.textMuted,
-    cols[1],
-    rows[1],
-    4.0,
-  )
-  addMetricBlock(
-    slide,
-    'Annual CO\u2082',
-    `${sus.annualCO2Kg.toFixed(0)} kg`,
-    BRAND.textMuted,
-    cols[2],
-    rows[1],
-    4.0,
-  )
-}
-
-/** Build the volumetry detail slide (Slide 3) with embedded Sankey PNG. */
-async function buildVolumetrySlide(
-  prs: pptxgen,
-  config: ExportConfig,
-  sankeyDataUrl: string | null,
-): Promise<void> {
-  const slide = prs.addSlide()
-  slide.background = { fill: BRAND.bg }
-  addAccentBar(slide, prs)
-  addSlideHeading(slide, i18n.t('output:pptx.volumetry'))
-
-  const vol = config.results.volumetry
-  addMetricBlock(
-    slide,
-    'Raw Capacity',
-    `${bytesToTB(vol.rawCapacity).toFixed(1)} TB`,
-    BRAND.textMuted,
-    0.4,
-    1.0,
-  )
-  addMetricBlock(
-    slide,
-    'Usable Capacity',
-    `${bytesToTB(vol.usableCapacity).toFixed(1)} TB`,
-    BRAND.capacity,
-    0.4,
-    2.2,
-  )
-  addMetricBlock(
-    slide,
-    'Effective Capacity',
-    `${bytesToTB(vol.effectiveCapacity).toFixed(1)} TB`,
-    BRAND.accent,
-    0.4,
-    3.4,
-  )
-  addMetricBlock(slide, 'Efficiency', `${vol.efficiency.toFixed(1)}%`, BRAND.overhead, 0.4, 4.6)
-
-  if (sankeyDataUrl) {
-    slide.addImage({ data: sankeyDataUrl, x: 4.2, y: 0.8, w: 8.7, h: 6.3 })
-  } else {
-    slide.addText('Chart not available', {
-      x: 4.2,
-      y: 3.0,
-      w: 8.7,
-      h: 0.5,
-      fontSize: 14,
-      color: BRAND.textMuted,
-      fontFace: 'Calibri',
-      align: 'center',
-    })
-  }
-}
-
-/** Build the performance detail slide (Slide 4) with embedded speedometer PNG. */
-async function buildPerformanceSlide(
-  prs: pptxgen,
-  config: ExportConfig,
-  speedometerDataUrl: string | null,
-): Promise<void> {
-  const slide = prs.addSlide()
-  slide.background = { fill: BRAND.bg }
-  addAccentBar(slide, prs)
-  addSlideHeading(slide, i18n.t('output:pptx.performance'))
-
-  const perf = config.results.performance
-  addMetricBlock(slide, 'Read IOPS', formatIops(perf.maxReadIOPS), BRAND.accent, 0.4, 1.0)
-  addMetricBlock(slide, 'Write IOPS', formatIops(perf.maxWriteIOPS), BRAND.accent, 0.4, 2.2)
-  addMetricBlock(
-    slide,
-    'Read Throughput',
-    `${perf.maxReadThroughputMBs.toFixed(0)} MB/s`,
-    BRAND.textMuted,
-    0.4,
-    3.4,
-  )
-  addMetricBlock(
-    slide,
-    'Write Throughput',
-    `${perf.maxWriteThroughputMBs.toFixed(0)} MB/s`,
-    BRAND.textMuted,
-    0.4,
-    4.6,
-  )
-
-  // Bottleneck description
-  slide.addText(perf.bottleneckDescription, {
-    x: 0.4,
-    y: 5.8,
-    w: 3.8,
-    h: 0.4,
-    fontSize: 12,
-    color: BRAND.textMuted,
-    fontFace: 'Calibri',
-    italic: true,
-  })
-
-  if (speedometerDataUrl) {
-    slide.addImage({ data: speedometerDataUrl, x: 4.5, y: 0.9, w: 5.5, h: 5.5 })
-  } else {
-    slide.addText('Chart not available', {
-      x: 4.5,
-      y: 3.0,
-      w: 8.0,
-      h: 0.5,
-      fontSize: 14,
-      color: BRAND.textMuted,
-      fontFace: 'Calibri',
-      align: 'center',
-    })
-  }
-}
-
-/** Build the resilience detail slide (Slide 5) with embedded donut chart PNG. */
-async function buildResilienceSlide(
-  prs: pptxgen,
-  config: ExportConfig,
-  donutDataUrl: string | null,
-): Promise<void> {
-  const slide = prs.addSlide()
-  slide.background = { fill: BRAND.bg }
-  addAccentBar(slide, prs)
-  addSlideHeading(slide, i18n.t('output:pptx.resilience'))
-
-  const resilience = config.results.resilience
-  if (!resilience) {
-    slide.addText('Resilience simulation not run', {
-      x: 4.5,
-      y: 3.5,
-      w: 4.5,
-      h: 0.5,
-      fontSize: 16,
-      color: BRAND.textMuted,
-      fontFace: 'Calibri',
-      align: 'center',
-    })
-    return
-  }
-
-  const riskColor =
-    resilience.riskLevel === 'low'
-      ? BRAND.capacity
-      : resilience.riskLevel === 'medium'
-        ? BRAND.overhead
-        : BRAND.parity
-
-  addMetricBlock(slide, 'Survival Rate', resilience.survivalPercent, BRAND.capacity, 0.4, 1.0)
-  addMetricBlock(slide, 'Nines', `${resilience.nines} nines`, BRAND.capacity, 0.4, 2.2)
-  addMetricBlock(
-    slide,
-    'Rebuild Time',
-    `${resilience.avgRebuildTimeHours.toFixed(1)} h`,
-    BRAND.overhead,
-    0.4,
-    3.4,
-  )
-  addMetricBlock(slide, 'Risk Level', resilience.riskLevel.toUpperCase(), riskColor, 0.4, 4.6)
-
-  if (donutDataUrl) {
-    slide.addImage({ data: donutDataUrl, x: 4.5, y: 0.9, w: 5.0, h: 5.0 })
-  } else {
-    slide.addText('Chart not available', {
-      x: 4.5,
-      y: 3.0,
-      w: 8.0,
-      h: 0.5,
-      fontSize: 14,
-      color: BRAND.textMuted,
-      fontFace: 'Calibri',
-      align: 'center',
-    })
-  }
-}
-
-/** Build the sustainability detail slide (Slide 6). */
-function buildSustainabilitySlide(prs: pptxgen, config: ExportConfig): void {
-  const slide = prs.addSlide()
-  slide.background = { fill: BRAND.bg }
-  addAccentBar(slide, prs)
-  addSlideHeading(slide, i18n.t('output:pptx.sustainability'))
-
-  const sus = config.results.sustainability
-  // Left column (x: 0.4)
-  addMetricBlock(
+  // Row 2
+  addCompactMetric(
     slide,
     'Total Power',
     `${sus.powerBreakdown.total.toFixed(0)} W`,
     BRAND.accent,
-    0.4,
-    1.0,
+    mcolX[0],
+    mrowY[1],
   )
-  addMetricBlock(
+  addCompactMetric(
     slide,
     'Annual Energy',
     `${sus.annualEnergyKwh.toFixed(0)} kWh`,
     BRAND.textMuted,
-    0.4,
-    2.2,
+    mcolX[1],
+    mrowY[1],
   )
-  addMetricBlock(
+  addCompactMetric(
     slide,
-    'Annual Cost',
-    `$${sus.annualEnergyCost.toFixed(0)}`,
-    BRAND.overhead,
-    0.4,
-    3.4,
-  )
-
-  // Right column (x: 6.8)
-  addMetricBlock(
-    slide,
-    'Annual CO\u2082',
+    'Annual CO₂',
     `${sus.annualCO2Kg.toFixed(0)} kg`,
     BRAND.textMuted,
-    6.8,
-    1.0,
+    mcolX[2],
+    mrowY[1],
   )
-  addMetricBlock(
-    slide,
-    'Drive Power',
-    `${sus.powerBreakdown.drives.toFixed(0)} W`,
-    BRAND.textMuted,
-    6.8,
-    2.2,
-  )
-  addMetricBlock(
-    slide,
-    'Server Power',
-    `${sus.powerBreakdown.servers.toFixed(0)} W`,
-    BRAND.textMuted,
-    6.8,
-    3.4,
-  )
+  const resilienceValue = resilience
+    ? `${resilience.survivalPercent} · ${resilience.nines} nines`
+    : '—'
+  addCompactMetric(slide, 'Survival', resilienceValue, BRAND.capacity, mcolX[3], mrowY[1])
 
-  if (sus.flashEndurance) {
-    addMetricBlock(
-      slide,
-      'Drive Endurance',
-      `${sus.flashEndurance.expectedLifeYears.toFixed(1)} years`,
-      BRAND.capacity,
-      0.4,
-      5.0,
-    )
-  }
-}
-
-/** Build the bill of materials slide (Slide 7). */
-function buildBomSlide(prs: pptxgen, config: ExportConfig): void {
-  const slide = prs.addSlide()
-  slide.background = { fill: BRAND.bg }
-  addAccentBar(slide, prs)
-  addSlideHeading(slide, i18n.t('output:pptx.bom'))
-
-  // Drive section label
-  slide.addText('Drive', {
-    x: 0.4,
-    y: 0.9,
-    w: 6.0,
-    h: 0.4,
-    fontSize: 14,
-    bold: true,
+  // ── Footer: bottleneck ────────────────────────────────────────────────
+  slide.addText(perf.bottleneckDescription, {
+    x: 3.7,
+    y: 6.8,
+    w: 9.3,
+    h: 0.35,
+    fontSize: 10,
+    italic: true,
     color: BRAND.textMuted,
     fontFace: 'Calibri',
-  })
-
-  const driveRows: Array<{ label: string; value: string }> = [
-    { label: 'Model', value: config.drive.model },
-    { label: 'Type', value: config.drive.type },
-    { label: 'Interface', value: config.drive.interface ?? 'N/A' },
-    { label: 'Capacity', value: `${bytesToTB(config.drive.capacity_raw).toFixed(1)} TB` },
-    { label: 'Active Power', value: `${config.drive.power.load_watts} W` },
-  ]
-  if (config.drive.reliability.dwpd > 0) {
-    driveRows.push({ label: 'DWPD', value: `${config.drive.reliability.dwpd}` })
-  }
-
-  driveRows.forEach((row, i) => {
-    const y = 1.3 + i * 0.55
-    slide.addText(row.label, {
-      x: 0.4,
-      y,
-      w: 2.5,
-      h: 0.4,
-      fontSize: 12,
-      color: BRAND.textMuted,
-      fontFace: 'Calibri',
-    })
-    slide.addText(row.value, {
-      x: 3.0,
-      y,
-      w: 3.5,
-      h: 0.4,
-      fontSize: 13,
-      bold: true,
-      color: BRAND.textWhite,
-      fontFace: 'Calibri',
-    })
-  })
-
-  // Configuration section label
-  slide.addText('Configuration', {
-    x: 7.0,
-    y: 0.9,
-    w: 6.0,
-    h: 0.4,
-    fontSize: 14,
-    bold: true,
-    color: BRAND.textMuted,
-    fontFace: 'Calibri',
-  })
-
-  const topLabel = `${config.topology.type.toUpperCase()}${'level' in config.topology ? ` ${config.topology.level}` : ''}`
-  const serverCount =
-    'serverCount' in config.topology
-      ? String((config.topology as { serverCount: number }).serverCount)
-      : 'N/A'
-
-  const configRows: Array<{ label: string; value: string }> = [
-    { label: 'Topology', value: topLabel },
-    { label: 'Drive Count', value: `${config.driveCount}` },
-    { label: 'Server Count', value: serverCount },
-  ]
-
-  configRows.forEach((row, i) => {
-    const y = 1.3 + i * 0.55
-    slide.addText(row.label, {
-      x: 7.0,
-      y,
-      w: 2.5,
-      h: 0.4,
-      fontSize: 12,
-      color: BRAND.textMuted,
-      fontFace: 'Calibri',
-    })
-    slide.addText(row.value, {
-      x: 9.6,
-      y,
-      w: 3.5,
-      h: 0.4,
-      fontSize: 13,
-      bold: true,
-      color: BRAND.textWhite,
-      fontFace: 'Calibri',
-    })
   })
 }
 
 /**
- * Generate and download a PPTX presentation.
+ * Generate and download a single-slide PPTX summary.
  * Runs entirely in the browser — no server request is made.
  */
 export async function exportToPptx(config: ExportConfig): Promise<void> {
-  // Capture all charts in parallel before building slides
-  const [sankeyDataUrl, speedometerDataUrl, donutDataUrl] = await Promise.all([
+  // Capture all charts in parallel before building the slide.
+  const [sankey, speedometer, donut] = await Promise.all([
     captureSankeyDiagram(),
     captureSpeedometer(),
     captureDonutChart(),
@@ -610,13 +311,7 @@ export async function exportToPptx(config: ExportConfig): Promise<void> {
   prs.subject = 'Storage Configuration'
   prs.title = config.projectName ?? 'Storage Report'
 
-  buildTitleSlide(prs, config)
-  buildExecutiveSummarySlide(prs, config)
-  await buildVolumetrySlide(prs, config, sankeyDataUrl)
-  await buildPerformanceSlide(prs, config, speedometerDataUrl)
-  await buildResilienceSlide(prs, config, donutDataUrl)
-  buildSustainabilitySlide(prs, config)
-  buildBomSlide(prs, config)
+  buildSummarySlide(prs, config, { sankey, speedometer, donut })
 
   const safeLabel = (config.topology.type ?? 'storage').replace(/[^a-z0-9]/gi, '-')
   await prs.writeFile({ fileName: `raidy-${safeLabel}.pptx` })

--- a/src/utils/exportPptx.ts
+++ b/src/utils/exportPptx.ts
@@ -1,9 +1,9 @@
 /**
  * PPTX Export utility using pptxgenjs.
- * Generates a single dense executive one-pager that mirrors the dashboard:
- * Sankey + performance gauges on top; power, backup, bottleneck, and the
- * resilience donut across the bottom. Charts are captured from the DOM via
- * html-to-image. No server requests — pptxgenjs runs entirely client-side.
+ * Single dense executive one-pager: a crystal-clear VOLUME spec and PERFORMANCE
+ * maximums on top (Sankey + gauges plus explicit number lines), with energy,
+ * bottlenecks, and resilience compressed underneath. Charts are captured from
+ * the DOM via html-to-image. No server requests — pptxgenjs runs client-side.
  */
 import pptxgen from 'pptxgenjs'
 
@@ -12,7 +12,7 @@ import type { Drive } from '@/types/drive'
 import type { CalculationResults } from '@/types/results'
 import type { Topology, ZfsOptions } from '@/types/topology'
 
-import { captureDonutChart, captureSankeyDiagram, captureSpeedometer } from './captureChart'
+import { captureSankeyDiagram, captureSpeedometer } from './captureChart'
 import type { UnitSystem } from './units'
 
 export interface ExportConfig {
@@ -24,6 +24,9 @@ export interface ExportConfig {
   projectName?: string
   unitSystem?: UnitSystem
 }
+
+/** Standard slide font. */
+const FONT = 'Arial'
 
 /** Brand color palette (6-char hex, no '#', required by pptxgenjs). */
 export const BRAND = {
@@ -41,6 +44,13 @@ export const BRAND = {
 /** Convert bytes to decimal terabytes (1 TB = 1e12 bytes). */
 function bytesToTB(bytes: number): number {
   return bytes / 1e12
+}
+
+/** Format IOPS with K/M suffix for compact display. */
+function formatIops(iops: number): string {
+  if (iops >= 1_000_000) return `${(iops / 1_000_000).toFixed(1)}M`
+  if (iops >= 1_000) return `${(iops / 1_000).toFixed(0)}K`
+  return iops.toFixed(0)
 }
 
 /** Add the thin accent bar at the top of the slide. */
@@ -62,7 +72,7 @@ function addSectionLabel(
   color: string,
   x: number,
   y: number,
-  w = 3.0,
+  w = 6.0,
 ): void {
   slide.addText(title.toUpperCase(), {
     x,
@@ -73,7 +83,7 @@ function addSectionLabel(
     bold: true,
     color,
     charSpacing: 1,
-    fontFace: 'Calibri',
+    fontFace: FONT,
   })
 }
 
@@ -95,71 +105,63 @@ function addChartOrFallback(
       fontSize: 11,
       color: BRAND.textMuted,
       italic: true,
-      fontFace: 'Calibri',
+      fontFace: FONT,
       align: 'center',
     })
   }
 }
 
-/** A compact single-line "label  value" row for the bottom data columns. */
-function addRow(
+/** A dense "label: value · label: value" stat line built from text runs. */
+type StatRun = { label: string; value: string; color: string }
+function addStatLine(
   slide: pptxgen.Slide,
-  label: string,
-  value: string,
-  color: string,
+  stats: StatRun[],
   x: number,
   y: number,
-  colW: number,
+  w: number,
+  fontSize = 11,
 ): void {
-  const labelW = colW * 0.56
-  slide.addText(label, {
-    x,
-    y,
-    w: labelW,
-    h: 0.32,
-    fontSize: 9.5,
-    color: BRAND.textMuted,
-    fontFace: 'Calibri',
-    valign: 'middle',
+  const runs: pptxgen.TextProps[] = []
+  stats.forEach((stat, i) => {
+    if (i > 0) {
+      runs.push({ text: '   ·   ', options: { color: BRAND.border, fontFace: FONT, fontSize } })
+    }
+    runs.push({
+      text: `${stat.label} `,
+      options: { color: BRAND.textMuted, fontFace: FONT, fontSize },
+    })
+    runs.push({
+      text: stat.value,
+      options: { color: stat.color, bold: true, fontFace: FONT, fontSize },
+    })
   })
-  slide.addText(value, {
-    x: x + labelW,
-    y,
-    w: colW - labelW,
-    h: 0.32,
-    fontSize: 10.5,
-    bold: true,
-    color,
-    fontFace: 'Calibri',
-    valign: 'middle',
-  })
+  slide.addText(runs, { x, y, w, h: 0.34, valign: 'middle', fontFace: FONT })
 }
 
 /** Build the single dense executive one-pager slide. */
 function buildSummarySlide(
   prs: pptxgen,
   config: ExportConfig,
-  charts: { sankey: string | null; speedometer: string | null; donut: string | null },
+  charts: { sankey: string | null; speedometer: string | null },
 ): void {
   const slide = prs.addSlide()
   slide.background = { fill: BRAND.bg }
   addAccentBar(slide, prs)
 
   const { volumetry: vol, performance: perf, resilience, sustainability: sus } = config.results
-  const backup = config.results.backup
 
-  // ── Header (topology + drive + counts + headline capacity numbers) ────
+  // ── Header ────────────────────────────────────────────────────────────
   const topologyLabel = config.topology.type.toUpperCase()
   const levelLabel = 'level' in config.topology ? ` ${config.topology.level}` : ''
   slide.addText(`${topologyLabel}${levelLabel}`, {
     x: 0.4,
-    y: 0.14,
-    w: 9.0,
-    h: 0.48,
-    fontSize: 20,
+    y: 0.12,
+    w: 12.6,
+    h: 0.5,
+    fontSize: 22,
     bold: true,
     color: BRAND.textWhite,
-    fontFace: 'Calibri',
+    fontFace: FONT,
   })
 
   const date = new Date().toLocaleDateString(i18n.language, {
@@ -176,220 +178,161 @@ function buildSummarySlide(
     `${config.driveCount} drives`,
     serverCount ? `${serverCount} servers` : null,
     date,
-    `${bytesToTB(vol.usableCapacity).toFixed(1)} TB usable`,
-    `${vol.efficiency.toFixed(1)}% efficiency`,
   ].filter(Boolean)
   slide.addText(subParts.join('  ·  '), {
     x: 0.4,
-    y: 0.64,
+    y: 0.66,
     w: 12.6,
     h: 0.28,
-    fontSize: 10.5,
+    fontSize: 11,
     color: BRAND.textMuted,
-    fontFace: 'Calibri',
+    fontFace: FONT,
   })
 
-  // ── Top row: Sankey (capacity) + performance gauges ───────────────────
-  addSectionLabel(slide, i18n.t('output:pptx.volumetry'), BRAND.capacity, 0.35, 0.98)
+  // ── VOLUME (top-left): Sankey + crystal-clear capacity breakdown ──────
+  addSectionLabel(slide, i18n.t('output:pptx.volumetry'), BRAND.capacity, 0.4, 1.0)
   addChartOrFallback(
     slide,
     charts.sankey,
-    { x: 0.35, y: 1.28, w: 6.6, h: 2.6 },
+    { x: 0.3, y: 1.3, w: 6.5, h: 2.3 },
     'Capacity chart unavailable',
   )
+  addStatLine(
+    slide,
+    [
+      {
+        label: 'Raw',
+        value: `${bytesToTB(vol.rawCapacity).toFixed(1)} TB`,
+        color: BRAND.textWhite,
+      },
+      {
+        label: 'Usable',
+        value: `${bytesToTB(vol.usableCapacity).toFixed(1)} TB`,
+        color: BRAND.capacity,
+      },
+      {
+        label: 'Effective',
+        value: `${bytesToTB(vol.effectiveCapacity).toFixed(1)} TB`,
+        color: BRAND.accent,
+      },
+      { label: 'Efficiency', value: `${vol.efficiency.toFixed(1)}%`, color: BRAND.overhead },
+    ],
+    0.4,
+    3.66,
+    6.5,
+  )
+  addStatLine(
+    slide,
+    [
+      {
+        label: 'Parity',
+        value: `${bytesToTB(vol.parityOverhead).toFixed(1)} TB`,
+        color: BRAND.parity,
+      },
+      {
+        label: 'Spares',
+        value: `${bytesToTB(vol.hotSpareOverhead).toFixed(1)} TB`,
+        color: BRAND.overhead,
+      },
+      {
+        label: 'FS',
+        value: `${bytesToTB(vol.filesystemOverhead).toFixed(1)} TB`,
+        color: BRAND.textMuted,
+      },
+    ],
+    0.4,
+    4.06,
+    6.5,
+    10,
+  )
 
-  addSectionLabel(slide, i18n.t('output:pptx.performance'), BRAND.accent, 7.1, 0.98)
+  // ── PERFORMANCE (top-right): gauges + crystal-clear maximums ──────────
+  addSectionLabel(slide, i18n.t('output:pptx.performance'), BRAND.accent, 7.0, 1.0)
   addChartOrFallback(
     slide,
     charts.speedometer,
-    { x: 7.1, y: 1.28, w: 5.9, h: 2.6 },
+    { x: 7.0, y: 1.3, w: 6.0, h: 2.3 },
     'Performance chart unavailable',
   )
+  addStatLine(
+    slide,
+    [
+      { label: 'Max Read', value: `${formatIops(perf.maxReadIOPS)} IOPS`, color: BRAND.accent },
+      { label: '/', value: `${perf.maxReadThroughputMBs.toFixed(0)} MB/s`, color: BRAND.textWhite },
+    ],
+    7.0,
+    3.66,
+    6.0,
+  )
+  addStatLine(
+    slide,
+    [
+      { label: 'Max Write', value: `${formatIops(perf.maxWriteIOPS)} IOPS`, color: BRAND.accent },
+      {
+        label: '/',
+        value: `${perf.maxWriteThroughputMBs.toFixed(0)} MB/s`,
+        color: BRAND.textWhite,
+      },
+    ],
+    7.0,
+    4.06,
+    6.0,
+  )
 
-  // ── Bottom row: four data columns ─────────────────────────────────────
-  const colW = 3.0
-  const cols: [number, number, number, number] = [0.35, 3.55, 6.7, 9.9]
-  const labelY = 4.15
-  const rowStart = 4.55
-  const pitch = 0.4
-  const rowY = (i: number): number => rowStart + i * pitch
-
-  // Col 1 — Sustainability (energy + power breakdown)
-  addSectionLabel(
-    slide,
-    i18n.t('output:pptx.sustainability'),
-    BRAND.overhead,
-    cols[0],
-    labelY,
-    colW,
-  )
-  addRow(
-    slide,
-    'Total Power',
-    `${sus.powerBreakdown.total.toFixed(0)} W`,
-    BRAND.accent,
-    cols[0],
-    rowY(0),
-    colW,
-  )
-  addRow(
-    slide,
-    'Annual Energy',
-    `${sus.annualEnergyKwh.toFixed(0)} kWh`,
-    BRAND.textWhite,
-    cols[0],
-    rowY(1),
-    colW,
-  )
-  addRow(
-    slide,
-    'Annual CO₂',
-    `${sus.annualCO2Kg.toFixed(0)} kg`,
-    BRAND.textWhite,
-    cols[0],
-    rowY(2),
-    colW,
-  )
-  addRow(
-    slide,
-    'Drives',
-    `${sus.powerBreakdown.drives.toFixed(0)} W`,
-    BRAND.textMuted,
-    cols[0],
-    rowY(3),
-    colW,
-  )
-  addRow(
-    slide,
-    'Servers',
-    `${sus.powerBreakdown.servers.toFixed(0)} W`,
-    BRAND.textMuted,
-    cols[0],
-    rowY(4),
-    colW,
-  )
-  addRow(
-    slide,
-    'Cooling',
-    `${sus.powerBreakdown.cooling.toFixed(0)} W`,
-    BRAND.textMuted,
-    cols[0],
-    rowY(5),
-    colW,
-  )
-  if (sus.flashEndurance) {
-    addRow(
-      slide,
-      'Endurance',
-      `${sus.flashEndurance.expectedLifeYears.toFixed(1)} yr`,
-      BRAND.capacity,
-      cols[0],
-      rowY(6),
-      colW,
-    )
-  }
-
-  // Col 2 — Backup
-  addSectionLabel(slide, i18n.t('output:pptx.backup'), BRAND.accent, cols[1], labelY, colW)
-  if (backup) {
-    addRow(
-      slide,
-      'Total Backup',
-      `${bytesToTB(backup.totalRaw).toFixed(1)} TB`,
-      BRAND.accent,
-      cols[1],
-      rowY(0),
-      colW,
-    )
-    addRow(
-      slide,
-      'Daily Change',
-      `${bytesToTB(backup.dailyChange).toFixed(1)} TB`,
-      BRAND.textWhite,
-      cols[1],
-      rowY(1),
-      colW,
-    )
-    addRow(
-      slide,
-      'Incremental',
-      `${bytesToTB(backup.incrementalRaw).toFixed(1)} TB`,
-      BRAND.textWhite,
-      cols[1],
-      rowY(2),
-      colW,
-    )
-    addRow(
-      slide,
-      'Retention',
-      `${backup.retentionDays} days`,
-      BRAND.textMuted,
-      cols[1],
-      rowY(3),
-      colW,
-    )
-    addRow(
-      slide,
-      'Change Rate',
-      `${backup.changeRatePercent}%`,
-      BRAND.textMuted,
-      cols[1],
-      rowY(4),
-      colW,
-    )
-  } else {
-    addRow(slide, 'Backup', 'Not configured', BRAND.textMuted, cols[1], rowY(0), colW)
-  }
-
-  // Col 3 — Bottleneck chain (Media → Controller → PCIe → Network)
-  addSectionLabel(slide, i18n.t('output:pptx.bottleneck'), BRAND.parity, cols[2], labelY, colW)
-  perf.layers.slice(0, 7).forEach((layer, i) => {
-    const name = layer.name.replace(/\s*\(.*\)\s*$/, '') // drop parenthetical detail
-    addRow(
-      slide,
-      layer.isBottleneck ? `▶ ${name}` : name,
-      `${layer.throughputMBs.toFixed(0)} MB/s`,
-      layer.isBottleneck ? BRAND.parity : BRAND.textMuted,
-      cols[2],
-      rowY(i),
-      colW,
-    )
-  })
-
-  // Col 4 — Resilience donut (or text fallback)
-  addSectionLabel(
-    slide,
-    i18n.t('output:pptx.resilience'),
-    BRAND.capacity,
-    cols[3],
-    labelY,
-    colW + 0.3,
-  )
-  if (charts.donut) {
-    addChartOrFallback(slide, charts.donut, { x: cols[3], y: 4.5, w: 3.3, h: 2.5 }, '')
-  } else if (resilience) {
-    addRow(slide, 'Survival', resilience.survivalPercent, BRAND.capacity, cols[3], rowY(0), colW)
-    addRow(slide, 'Durability', `${resilience.nines} nines`, BRAND.capacity, cols[3], rowY(1), colW)
-    addRow(
-      slide,
-      'Risk',
-      resilience.riskLevel.toUpperCase(),
-      BRAND.overhead,
-      cols[3],
-      rowY(2),
-      colW,
-    )
-  } else {
-    slide.addText('Simulation not run', {
-      x: cols[3],
-      y: rowY(0),
-      w: colW + 0.3,
-      h: 0.32,
-      fontSize: 10,
-      italic: true,
+  // ── EXTRAS (compact, full-width dense lines) ──────────────────────────
+  addSectionLabel(slide, i18n.t('output:pptx.sustainability'), BRAND.overhead, 0.4, 4.65)
+  const energyStats: StatRun[] = [
+    { label: 'Total', value: `${sus.powerBreakdown.total.toFixed(0)} W`, color: BRAND.accent },
+    { label: 'Drives', value: `${sus.powerBreakdown.drives.toFixed(0)} W`, color: BRAND.textMuted },
+    {
+      label: 'Servers',
+      value: `${sus.powerBreakdown.servers.toFixed(0)} W`,
       color: BRAND.textMuted,
-      fontFace: 'Calibri',
+    },
+    {
+      label: 'Cooling',
+      value: `${sus.powerBreakdown.cooling.toFixed(0)} W`,
+      color: BRAND.textMuted,
+    },
+    { label: 'Energy', value: `${sus.annualEnergyKwh.toFixed(0)} kWh/yr`, color: BRAND.textWhite },
+    { label: 'CO₂', value: `${sus.annualCO2Kg.toFixed(0)} kg/yr`, color: BRAND.textWhite },
+  ]
+  if (sus.flashEndurance) {
+    energyStats.push({
+      label: 'Endurance',
+      value: `${sus.flashEndurance.expectedLifeYears.toFixed(1)} yr`,
+      color: BRAND.capacity,
     })
+  }
+  addStatLine(slide, energyStats, 0.4, 4.98, 12.6)
+
+  addSectionLabel(slide, i18n.t('output:pptx.bottleneck'), BRAND.parity, 0.4, 5.5)
+  const layerStats: StatRun[] = perf.layers.slice(0, 6).map((layer) => ({
+    label: layer.name.replace(/\s*\(.*\)\s*$/, ''),
+    value: `${layer.throughputMBs.toFixed(0)} MB/s`,
+    color: layer.isBottleneck ? BRAND.parity : BRAND.textWhite,
+  }))
+  addStatLine(slide, layerStats, 0.4, 5.83, 12.6)
+
+  // ── RESILIENCE — only when the simulation has actually been run ───────
+  if (resilience) {
+    addSectionLabel(slide, i18n.t('output:pptx.resilience'), BRAND.capacity, 0.4, 6.35)
+    addStatLine(
+      slide,
+      [
+        { label: 'Survival', value: resilience.survivalPercent, color: BRAND.capacity },
+        { label: 'Durability', value: `${resilience.nines} nines`, color: BRAND.capacity },
+        {
+          label: 'Rebuild',
+          value: `${resilience.avgRebuildTimeHours.toFixed(1)} h`,
+          color: BRAND.textMuted,
+        },
+        { label: 'Risk', value: resilience.riskLevel.toUpperCase(), color: BRAND.overhead },
+      ],
+      0.4,
+      6.68,
+      12.6,
+    )
   }
 }
 
@@ -398,12 +341,8 @@ function buildSummarySlide(
  * Runs entirely in the browser — no server request is made.
  */
 export async function exportToPptx(config: ExportConfig): Promise<void> {
-  // Capture all charts in parallel before building the slide.
-  const [sankey, speedometer, donut] = await Promise.all([
-    captureSankeyDiagram(),
-    captureSpeedometer(),
-    captureDonutChart(),
-  ])
+  // Capture the charts in parallel before building the slide.
+  const [sankey, speedometer] = await Promise.all([captureSankeyDiagram(), captureSpeedometer()])
 
   const prs = new pptxgen()
   prs.layout = 'LAYOUT_WIDE' // 13.33" × 7.5"
@@ -411,7 +350,7 @@ export async function exportToPptx(config: ExportConfig): Promise<void> {
   prs.subject = 'Storage Configuration'
   prs.title = config.projectName ?? 'Storage Report'
 
-  buildSummarySlide(prs, config, { sankey, speedometer, donut })
+  buildSummarySlide(prs, config, { sankey, speedometer })
 
   const safeLabel = (config.topology.type ?? 'storage').replace(/[^a-z0-9]/gi, '-')
   await prs.writeFile({ fileName: `raidy-${safeLabel}.pptx` })

--- a/src/utils/exportPptx.ts
+++ b/src/utils/exportPptx.ts
@@ -196,26 +196,27 @@ function buildSummarySlide(
   const chartH = resilience ? 2.7 : 3.2
   const chartBottom = chartTop + chartH
 
+  // Wider Sankey (reads like the web); smaller gauges packed to the right.
   addSectionLabel(slide, i18n.t('output:pptx.volumetry'), BRAND.capacity, 0.4, 1.0)
   addChartOrFallback(
     slide,
     charts.sankey,
-    { x: 0.25, y: chartTop, w: 6.8, h: chartH },
+    { x: 0.25, y: chartTop, w: 7.6, h: chartH },
     'Capacity chart unavailable',
   )
 
-  addSectionLabel(slide, i18n.t('output:pptx.performance'), BRAND.accent, 7.05, 1.0)
-  const gaugeColX: [number, number] = [7.05, 10.05]
-  const gaugeRowY: [number, number] = [chartTop, chartTop + chartH / 2]
-  const gaugeW = 2.95
-  const gaugeH = chartH / 2 - 0.05
+  addSectionLabel(slide, i18n.t('output:pptx.performance'), BRAND.accent, 8.0, 1.0)
+  const gaugeColX: [number, number] = [8.0, 10.5]
+  const gaugeRowY: [number, number] = [chartTop + 0.1, chartTop + chartH / 2 + 0.05]
+  const gaugeW = 2.45
+  const gaugeH = chartH / 2 - 0.35
   charts.gauges.forEach((gauge, i) => {
     const col = i % 2
     const row = i < 2 ? 0 : 1
     addChartOrFallback(
       slide,
       gauge,
-      { x: gaugeColX[col] ?? 7.05, y: gaugeRowY[row] ?? chartTop, w: gaugeW, h: gaugeH },
+      { x: gaugeColX[col] ?? 8.0, y: gaugeRowY[row] ?? chartTop, w: gaugeW, h: gaugeH },
       '',
     )
   })
@@ -245,7 +246,7 @@ function buildSummarySlide(
     ],
     0.4,
     nl0,
-    6.8,
+    7.6,
   )
   addStatLine(
     slide,
@@ -268,7 +269,7 @@ function buildSummarySlide(
     ],
     0.4,
     nl1,
-    6.8,
+    7.6,
     10,
   )
   addStatLine(
@@ -277,9 +278,9 @@ function buildSummarySlide(
       { label: 'Max Read', value: `${formatIops(perf.maxReadIOPS)} IOPS`, color: BRAND.accent },
       { label: '/', value: `${perf.maxReadThroughputMBs.toFixed(0)} MB/s`, color: BRAND.textWhite },
     ],
-    7.05,
+    8.0,
     nl0,
-    6.0,
+    5.0,
   )
   addStatLine(
     slide,
@@ -291,9 +292,9 @@ function buildSummarySlide(
         color: BRAND.textWhite,
       },
     ],
-    7.05,
+    8.0,
     nl1,
-    6.0,
+    5.0,
   )
 
   // ── Extras spread to fill the page ────────────────────────────────────

--- a/src/utils/exportPptx.ts
+++ b/src/utils/exportPptx.ts
@@ -1,9 +1,9 @@
 /**
  * PPTX Export utility using pptxgenjs.
- * Generates a single-slide, in-browser executive one-pager with the Sankey,
- * speedometers, and resilience donut plus a compact metric grid. Charts are
- * captured from the DOM via html-to-image. No server requests — pptxgenjs runs
- * entirely client-side.
+ * Generates a single dense executive one-pager that mirrors the dashboard:
+ * Sankey + performance gauges on top; power, backup, bottleneck, and the
+ * resilience donut across the bottom. Charts are captured from the DOM via
+ * html-to-image. No server requests — pptxgenjs runs entirely client-side.
  */
 import pptxgen from 'pptxgenjs'
 
@@ -43,13 +43,6 @@ function bytesToTB(bytes: number): number {
   return bytes / 1e12
 }
 
-/** Format IOPS with K/M suffix for compact display. */
-function formatIops(iops: number): string {
-  if (iops >= 1_000_000) return `${(iops / 1_000_000).toFixed(1)}M`
-  if (iops >= 1_000) return `${(iops / 1_000).toFixed(0)}K`
-  return iops.toFixed(0)
-}
-
 /** Add the thin accent bar at the top of the slide. */
 function addAccentBar(slide: pptxgen.Slide, prs: pptxgen): void {
   slide.addShape(prs.ShapeType.rect, {
@@ -69,11 +62,12 @@ function addSectionLabel(
   color: string,
   x: number,
   y: number,
+  w = 3.0,
 ): void {
   slide.addText(title.toUpperCase(), {
     x,
     y,
-    w: 6.0,
+    w,
     h: 0.3,
     fontSize: 12,
     bold: true,
@@ -98,7 +92,7 @@ function addChartOrFallback(
       y: box.y + box.h / 2 - 0.25,
       w: box.w,
       h: 0.5,
-      fontSize: 12,
+      fontSize: 11,
       color: BRAND.textMuted,
       italic: true,
       fontFace: 'Calibri',
@@ -107,37 +101,41 @@ function addChartOrFallback(
   }
 }
 
-/** A compact label-over-value metric for the bottom grid. */
-function addCompactMetric(
+/** A compact single-line "label  value" row for the bottom data columns. */
+function addRow(
   slide: pptxgen.Slide,
   label: string,
   value: string,
   color: string,
   x: number,
   y: number,
+  colW: number,
 ): void {
+  const labelW = colW * 0.56
   slide.addText(label, {
     x,
     y,
-    w: 2.3,
-    h: 0.26,
-    fontSize: 10,
+    w: labelW,
+    h: 0.32,
+    fontSize: 9.5,
     color: BRAND.textMuted,
     fontFace: 'Calibri',
+    valign: 'middle',
   })
   slide.addText(value, {
-    x,
-    y: y + 0.28,
-    w: 2.3,
-    h: 0.4,
-    fontSize: 15,
+    x: x + labelW,
+    y,
+    w: colW - labelW,
+    h: 0.32,
+    fontSize: 10.5,
     bold: true,
     color,
     fontFace: 'Calibri',
+    valign: 'middle',
   })
 }
 
-/** Build the single executive one-pager slide (charts + metric grid). */
+/** Build the single dense executive one-pager slide. */
 function buildSummarySlide(
   prs: pptxgen,
   config: ExportConfig,
@@ -148,15 +146,16 @@ function buildSummarySlide(
   addAccentBar(slide, prs)
 
   const { volumetry: vol, performance: perf, resilience, sustainability: sus } = config.results
+  const backup = config.results.backup
 
-  // ── Header ────────────────────────────────────────────────────────────
+  // ── Header (topology + drive + counts + headline capacity numbers) ────
   const topologyLabel = config.topology.type.toUpperCase()
   const levelLabel = 'level' in config.topology ? ` ${config.topology.level}` : ''
   slide.addText(`${topologyLabel}${levelLabel}`, {
     x: 0.4,
-    y: 0.16,
+    y: 0.14,
     w: 9.0,
-    h: 0.5,
+    h: 0.48,
     fontSize: 20,
     bold: true,
     color: BRAND.textWhite,
@@ -177,120 +176,221 @@ function buildSummarySlide(
     `${config.driveCount} drives`,
     serverCount ? `${serverCount} servers` : null,
     date,
+    `${bytesToTB(vol.usableCapacity).toFixed(1)} TB usable`,
+    `${vol.efficiency.toFixed(1)}% efficiency`,
   ].filter(Boolean)
   slide.addText(subParts.join('  ·  '), {
     x: 0.4,
-    y: 0.68,
-    w: 12.5,
+    y: 0.64,
+    w: 12.6,
     h: 0.28,
     fontSize: 10.5,
     color: BRAND.textMuted,
     fontFace: 'Calibri',
   })
 
-  // ── Top row: Sankey (capacity) + Speedometers (performance) ───────────
-  addSectionLabel(slide, i18n.t('output:pptx.volumetry'), BRAND.capacity, 0.35, 1.0)
+  // ── Top row: Sankey (capacity) + performance gauges ───────────────────
+  addSectionLabel(slide, i18n.t('output:pptx.volumetry'), BRAND.capacity, 0.35, 0.98)
   addChartOrFallback(
     slide,
     charts.sankey,
-    { x: 0.35, y: 1.32, w: 6.7, h: 2.7 },
+    { x: 0.35, y: 1.28, w: 6.6, h: 2.6 },
     'Capacity chart unavailable',
   )
 
-  addSectionLabel(slide, i18n.t('output:pptx.performance'), BRAND.accent, 7.2, 1.0)
+  addSectionLabel(slide, i18n.t('output:pptx.performance'), BRAND.accent, 7.1, 0.98)
   addChartOrFallback(
     slide,
     charts.speedometer,
-    { x: 7.2, y: 1.32, w: 5.8, h: 2.7 },
+    { x: 7.1, y: 1.28, w: 5.9, h: 2.6 },
     'Performance chart unavailable',
   )
 
-  // ── Bottom row: Resilience donut + key-metric grid ────────────────────
-  addSectionLabel(slide, i18n.t('output:pptx.resilience'), BRAND.capacity, 0.35, 4.1)
-  addChartOrFallback(
-    slide,
-    charts.donut,
-    { x: 0.35, y: 4.4, w: 2.9, h: 2.5 },
-    'Resilience simulation not run',
-  )
+  // ── Bottom row: four data columns ─────────────────────────────────────
+  const colW = 3.0
+  const cols: [number, number, number, number] = [0.35, 3.55, 6.7, 9.9]
+  const labelY = 4.15
+  const rowStart = 4.55
+  const pitch = 0.4
+  const rowY = (i: number): number => rowStart + i * pitch
 
-  addSectionLabel(slide, i18n.t('output:pptx.executiveSummary'), BRAND.textMuted, 3.7, 4.1)
-  const mcolX: [number, number, number, number] = [3.7, 6.05, 8.4, 10.75]
-  const mrowY: [number, number] = [4.45, 5.7]
-  // Row 1
-  addCompactMetric(
+  // Col 1 — Sustainability (energy + power breakdown)
+  addSectionLabel(
     slide,
-    'Usable Capacity',
-    `${bytesToTB(vol.usableCapacity).toFixed(1)} TB`,
-    BRAND.capacity,
-    mcolX[0],
-    mrowY[0],
-  )
-  addCompactMetric(
-    slide,
-    'Efficiency',
-    `${vol.efficiency.toFixed(1)}%`,
+    i18n.t('output:pptx.sustainability'),
     BRAND.overhead,
-    mcolX[1],
-    mrowY[0],
+    cols[0],
+    labelY,
+    colW,
   )
-  addCompactMetric(
-    slide,
-    'Read IOPS',
-    formatIops(perf.maxReadIOPS),
-    BRAND.accent,
-    mcolX[2],
-    mrowY[0],
-  )
-  addCompactMetric(
-    slide,
-    'Write IOPS',
-    formatIops(perf.maxWriteIOPS),
-    BRAND.accent,
-    mcolX[3],
-    mrowY[0],
-  )
-  // Row 2
-  addCompactMetric(
+  addRow(
     slide,
     'Total Power',
     `${sus.powerBreakdown.total.toFixed(0)} W`,
     BRAND.accent,
-    mcolX[0],
-    mrowY[1],
+    cols[0],
+    rowY(0),
+    colW,
   )
-  addCompactMetric(
+  addRow(
     slide,
     'Annual Energy',
     `${sus.annualEnergyKwh.toFixed(0)} kWh`,
-    BRAND.textMuted,
-    mcolX[1],
-    mrowY[1],
+    BRAND.textWhite,
+    cols[0],
+    rowY(1),
+    colW,
   )
-  addCompactMetric(
+  addRow(
     slide,
     'Annual CO₂',
     `${sus.annualCO2Kg.toFixed(0)} kg`,
-    BRAND.textMuted,
-    mcolX[2],
-    mrowY[1],
+    BRAND.textWhite,
+    cols[0],
+    rowY(2),
+    colW,
   )
-  const resilienceValue = resilience
-    ? `${resilience.survivalPercent} · ${resilience.nines} nines`
-    : '—'
-  addCompactMetric(slide, 'Survival', resilienceValue, BRAND.capacity, mcolX[3], mrowY[1])
+  addRow(
+    slide,
+    'Drives',
+    `${sus.powerBreakdown.drives.toFixed(0)} W`,
+    BRAND.textMuted,
+    cols[0],
+    rowY(3),
+    colW,
+  )
+  addRow(
+    slide,
+    'Servers',
+    `${sus.powerBreakdown.servers.toFixed(0)} W`,
+    BRAND.textMuted,
+    cols[0],
+    rowY(4),
+    colW,
+  )
+  addRow(
+    slide,
+    'Cooling',
+    `${sus.powerBreakdown.cooling.toFixed(0)} W`,
+    BRAND.textMuted,
+    cols[0],
+    rowY(5),
+    colW,
+  )
+  if (sus.flashEndurance) {
+    addRow(
+      slide,
+      'Endurance',
+      `${sus.flashEndurance.expectedLifeYears.toFixed(1)} yr`,
+      BRAND.capacity,
+      cols[0],
+      rowY(6),
+      colW,
+    )
+  }
 
-  // ── Footer: bottleneck ────────────────────────────────────────────────
-  slide.addText(perf.bottleneckDescription, {
-    x: 3.7,
-    y: 6.8,
-    w: 9.3,
-    h: 0.35,
-    fontSize: 10,
-    italic: true,
-    color: BRAND.textMuted,
-    fontFace: 'Calibri',
+  // Col 2 — Backup
+  addSectionLabel(slide, i18n.t('output:pptx.backup'), BRAND.accent, cols[1], labelY, colW)
+  if (backup) {
+    addRow(
+      slide,
+      'Total Backup',
+      `${bytesToTB(backup.totalRaw).toFixed(1)} TB`,
+      BRAND.accent,
+      cols[1],
+      rowY(0),
+      colW,
+    )
+    addRow(
+      slide,
+      'Daily Change',
+      `${bytesToTB(backup.dailyChange).toFixed(1)} TB`,
+      BRAND.textWhite,
+      cols[1],
+      rowY(1),
+      colW,
+    )
+    addRow(
+      slide,
+      'Incremental',
+      `${bytesToTB(backup.incrementalRaw).toFixed(1)} TB`,
+      BRAND.textWhite,
+      cols[1],
+      rowY(2),
+      colW,
+    )
+    addRow(
+      slide,
+      'Retention',
+      `${backup.retentionDays} days`,
+      BRAND.textMuted,
+      cols[1],
+      rowY(3),
+      colW,
+    )
+    addRow(
+      slide,
+      'Change Rate',
+      `${backup.changeRatePercent}%`,
+      BRAND.textMuted,
+      cols[1],
+      rowY(4),
+      colW,
+    )
+  } else {
+    addRow(slide, 'Backup', 'Not configured', BRAND.textMuted, cols[1], rowY(0), colW)
+  }
+
+  // Col 3 — Bottleneck chain (Media → Controller → PCIe → Network)
+  addSectionLabel(slide, i18n.t('output:pptx.bottleneck'), BRAND.parity, cols[2], labelY, colW)
+  perf.layers.slice(0, 7).forEach((layer, i) => {
+    const name = layer.name.replace(/\s*\(.*\)\s*$/, '') // drop parenthetical detail
+    addRow(
+      slide,
+      layer.isBottleneck ? `▶ ${name}` : name,
+      `${layer.throughputMBs.toFixed(0)} MB/s`,
+      layer.isBottleneck ? BRAND.parity : BRAND.textMuted,
+      cols[2],
+      rowY(i),
+      colW,
+    )
   })
+
+  // Col 4 — Resilience donut (or text fallback)
+  addSectionLabel(
+    slide,
+    i18n.t('output:pptx.resilience'),
+    BRAND.capacity,
+    cols[3],
+    labelY,
+    colW + 0.3,
+  )
+  if (charts.donut) {
+    addChartOrFallback(slide, charts.donut, { x: cols[3], y: 4.5, w: 3.3, h: 2.5 }, '')
+  } else if (resilience) {
+    addRow(slide, 'Survival', resilience.survivalPercent, BRAND.capacity, cols[3], rowY(0), colW)
+    addRow(slide, 'Durability', `${resilience.nines} nines`, BRAND.capacity, cols[3], rowY(1), colW)
+    addRow(
+      slide,
+      'Risk',
+      resilience.riskLevel.toUpperCase(),
+      BRAND.overhead,
+      cols[3],
+      rowY(2),
+      colW,
+    )
+  } else {
+    slide.addText('Simulation not run', {
+      x: cols[3],
+      y: rowY(0),
+      w: colW + 0.3,
+      h: 0.32,
+      fontSize: 10,
+      italic: true,
+      color: BRAND.textMuted,
+      fontFace: 'Calibri',
+    })
+  }
 }
 
 /**

--- a/src/utils/exportPptx.ts
+++ b/src/utils/exportPptx.ts
@@ -1,9 +1,10 @@
 /**
  * PPTX Export utility using pptxgenjs.
  * Single dense executive one-pager: a crystal-clear VOLUME spec and PERFORMANCE
- * maximums on top (Sankey + gauges plus explicit number lines), with energy,
- * bottlenecks, and resilience compressed underneath. Charts are captured from
- * the DOM via html-to-image. No server requests — pptxgenjs runs client-side.
+ * maximums on top (a large Sankey + a tight 2×2 of gauges, each with explicit
+ * number lines), with energy, bottlenecks, and resilience spread underneath to
+ * fill the page. Charts are captured from the DOM via html-to-image. No server
+ * requests — pptxgenjs runs entirely client-side.
  */
 import pptxgen from 'pptxgenjs'
 
@@ -12,7 +13,7 @@ import type { Drive } from '@/types/drive'
 import type { CalculationResults } from '@/types/results'
 import type { Topology, ZfsOptions } from '@/types/topology'
 
-import { captureSankeyDiagram, captureSpeedometer } from './captureChart'
+import { capturePerfGauges, captureSankeyDiagram } from './captureChart'
 import type { UnitSystem } from './units'
 
 export interface ExportConfig {
@@ -96,7 +97,7 @@ function addChartOrFallback(
 ): void {
   if (dataUrl) {
     slide.addImage({ data: dataUrl, sizing: { type: 'contain', w: box.w, h: box.h }, ...box })
-  } else {
+  } else if (fallback) {
     slide.addText(fallback, {
       x: box.x,
       y: box.y + box.h / 2 - 0.25,
@@ -111,7 +112,7 @@ function addChartOrFallback(
   }
 }
 
-/** A dense "label: value · label: value" stat line built from text runs. */
+/** A dense "label value · label value" stat line built from text runs. */
 type StatRun = { label: string; value: string; color: string }
 function addStatLine(
   slide: pptxgen.Slide,
@@ -142,7 +143,7 @@ function addStatLine(
 function buildSummarySlide(
   prs: pptxgen,
   config: ExportConfig,
-  charts: { sankey: string | null; speedometer: string | null },
+  charts: { sankey: string | null; gauges: (string | null)[] },
 ): void {
   const slide = prs.addSlide()
   slide.background = { fill: BRAND.bg }
@@ -189,14 +190,39 @@ function buildSummarySlide(
     fontFace: FONT,
   })
 
-  // ── VOLUME (top-left): Sankey + crystal-clear capacity breakdown ──────
+  // ── Top charts: large Sankey (left) + tight 2×2 gauges (right) ────────
+  // Shorter charts when resilience is shown, to leave room for its row.
+  const chartTop = 1.4
+  const chartH = resilience ? 2.7 : 3.2
+  const chartBottom = chartTop + chartH
+
   addSectionLabel(slide, i18n.t('output:pptx.volumetry'), BRAND.capacity, 0.4, 1.0)
   addChartOrFallback(
     slide,
     charts.sankey,
-    { x: 0.3, y: 1.3, w: 6.5, h: 2.3 },
+    { x: 0.25, y: chartTop, w: 6.8, h: chartH },
     'Capacity chart unavailable',
   )
+
+  addSectionLabel(slide, i18n.t('output:pptx.performance'), BRAND.accent, 7.05, 1.0)
+  const gaugeColX: [number, number] = [7.05, 10.05]
+  const gaugeRowY: [number, number] = [chartTop, chartTop + chartH / 2]
+  const gaugeW = 2.95
+  const gaugeH = chartH / 2 - 0.05
+  charts.gauges.forEach((gauge, i) => {
+    const col = i % 2
+    const row = i < 2 ? 0 : 1
+    addChartOrFallback(
+      slide,
+      gauge,
+      { x: gaugeColX[col] ?? 7.05, y: gaugeRowY[row] ?? chartTop, w: gaugeW, h: gaugeH },
+      '',
+    )
+  })
+
+  // ── Crystal-clear number lines beneath each chart ─────────────────────
+  const nl0 = chartBottom + 0.14
+  const nl1 = nl0 + 0.36
   addStatLine(
     slide,
     [
@@ -218,8 +244,8 @@ function buildSummarySlide(
       { label: 'Efficiency', value: `${vol.efficiency.toFixed(1)}%`, color: BRAND.overhead },
     ],
     0.4,
-    3.66,
-    6.5,
+    nl0,
+    6.8,
   )
   addStatLine(
     slide,
@@ -241,18 +267,9 @@ function buildSummarySlide(
       },
     ],
     0.4,
-    4.06,
-    6.5,
+    nl1,
+    6.8,
     10,
-  )
-
-  // ── PERFORMANCE (top-right): gauges + crystal-clear maximums ──────────
-  addSectionLabel(slide, i18n.t('output:pptx.performance'), BRAND.accent, 7.0, 1.0)
-  addChartOrFallback(
-    slide,
-    charts.speedometer,
-    { x: 7.0, y: 1.3, w: 6.0, h: 2.3 },
-    'Performance chart unavailable',
   )
   addStatLine(
     slide,
@@ -260,8 +277,8 @@ function buildSummarySlide(
       { label: 'Max Read', value: `${formatIops(perf.maxReadIOPS)} IOPS`, color: BRAND.accent },
       { label: '/', value: `${perf.maxReadThroughputMBs.toFixed(0)} MB/s`, color: BRAND.textWhite },
     ],
-    7.0,
-    3.66,
+    7.05,
+    nl0,
     6.0,
   )
   addStatLine(
@@ -274,13 +291,15 @@ function buildSummarySlide(
         color: BRAND.textWhite,
       },
     ],
-    7.0,
-    4.06,
+    7.05,
+    nl1,
     6.0,
   )
 
-  // ── EXTRAS (compact, full-width dense lines) ──────────────────────────
-  addSectionLabel(slide, i18n.t('output:pptx.sustainability'), BRAND.overhead, 0.4, 4.65)
+  // ── Extras spread to fill the page ────────────────────────────────────
+  let y = nl1 + 0.5
+
+  addSectionLabel(slide, i18n.t('output:pptx.sustainability'), BRAND.overhead, 0.4, y)
   const energyStats: StatRun[] = [
     { label: 'Total', value: `${sus.powerBreakdown.total.toFixed(0)} W`, color: BRAND.accent },
     { label: 'Drives', value: `${sus.powerBreakdown.drives.toFixed(0)} W`, color: BRAND.textMuted },
@@ -304,19 +323,21 @@ function buildSummarySlide(
       color: BRAND.capacity,
     })
   }
-  addStatLine(slide, energyStats, 0.4, 4.98, 12.6)
+  addStatLine(slide, energyStats, 0.4, y + 0.33, 12.6)
+  y += 0.85
 
-  addSectionLabel(slide, i18n.t('output:pptx.bottleneck'), BRAND.parity, 0.4, 5.5)
+  addSectionLabel(slide, i18n.t('output:pptx.bottleneck'), BRAND.parity, 0.4, y)
   const layerStats: StatRun[] = perf.layers.slice(0, 6).map((layer) => ({
     label: layer.name.replace(/\s*\(.*\)\s*$/, ''),
     value: `${layer.throughputMBs.toFixed(0)} MB/s`,
     color: layer.isBottleneck ? BRAND.parity : BRAND.textWhite,
   }))
-  addStatLine(slide, layerStats, 0.4, 5.83, 12.6)
+  addStatLine(slide, layerStats, 0.4, y + 0.33, 12.6)
+  y += 0.85
 
-  // ── RESILIENCE — only when the simulation has actually been run ───────
+  // Resilience — only when the simulation has actually been run.
   if (resilience) {
-    addSectionLabel(slide, i18n.t('output:pptx.resilience'), BRAND.capacity, 0.4, 6.35)
+    addSectionLabel(slide, i18n.t('output:pptx.resilience'), BRAND.capacity, 0.4, y)
     addStatLine(
       slide,
       [
@@ -330,7 +351,7 @@ function buildSummarySlide(
         { label: 'Risk', value: resilience.riskLevel.toUpperCase(), color: BRAND.overhead },
       ],
       0.4,
-      6.68,
+      y + 0.33,
       12.6,
     )
   }
@@ -342,7 +363,7 @@ function buildSummarySlide(
  */
 export async function exportToPptx(config: ExportConfig): Promise<void> {
   // Capture the charts in parallel before building the slide.
-  const [sankey, speedometer] = await Promise.all([captureSankeyDiagram(), captureSpeedometer()])
+  const [sankey, gauges] = await Promise.all([captureSankeyDiagram(), capturePerfGauges()])
 
   const prs = new pptxgen()
   prs.layout = 'LAYOUT_WIDE' // 13.33" × 7.5"
@@ -350,7 +371,7 @@ export async function exportToPptx(config: ExportConfig): Promise<void> {
   prs.subject = 'Storage Configuration'
   prs.title = config.projectName ?? 'Storage Report'
 
-  buildSummarySlide(prs, config, { sankey, speedometer })
+  buildSummarySlide(prs, config, { sankey, gauges })
 
   const safeLabel = (config.topology.type ?? 'storage').replace(/[^a-z0-9]/gi, '-')
   await prs.writeFile({ fileName: `raidy-${safeLabel}.pptx` })

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,7 +2,6 @@
  * Utility exports.
  */
 
-export { captureSankeyDiagram } from './captureChart'
 export {
   downloadAnsible,
   downloadTerraform,


### PR DESCRIPTION
Collapse the PowerPoint export from a 7-slide deck to **one executive slide** while keeping all the visuals.

### Layout (single slide)
- **Top-left** — Sankey capacity waterfall
- **Top-right** — performance speedometer gauges
- **Bottom-left** — resilience donut
- **Bottom-right** — key-metrics grid (usable capacity, efficiency, R/W IOPS, power, energy, CO₂, survival) + bottleneck footer

Charts are captured from the dashboard DOM as before; a missing chart (e.g. resilience not run) falls back to a muted note. Removes the now-unused `captureSankeyDiagram` barrel export.

Verification: typecheck 0 · lint 0 · 881 tests · build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * PowerPoint export now generates a single executive one-pager instead of a multi-slide deck, featuring consolidated key metrics, capacity waterfall, performance gauges, resilience summary, and bottleneck insights on one page.

* **Documentation**
  * Added translations for new export sections in German, English, French, and Italian.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjacquet/raidy/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->