### PR TITLE
Auto light/dark mode — web + theme-following PPTX (v1.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2026-05-24
+
+### Added
+- **Auto light/dark mode.** A header toggle (Auto / Light / Dark) switches the theme; Auto follows the OS (`prefers-color-scheme`) and reacts to changes. The preference persists (`raidy-theme`) and applies before first paint (no flash). Built on Tailwind's class-based `dark:` variant.
+- The PowerPoint export **follows the app theme** — a light deck (white paper) in light mode, the dark deck in dark mode, with charts captured on a matching background.
+
 ## [1.6.1] - 2026-05-24
 
 ### Changed

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -55,3 +55,9 @@ Path aliases are mirrored in `vite.config.ts` and `vitest.config.ts` `resolve.al
 - Default branch: **`maincd`**.
 - Conventional-commit style with phase/scope: `<type>(<scope>): …`, e.g. `feat(17-02): …`, `fix(pptx): …`, `chore(deps): …`.
 - CI runs the full gate set on push/PR to `maincd` — run `npm run typecheck`, `npm run lint`, and `npm run test:run` locally first.
+
+## Theming (light/dark)
+
+Class-based dark mode via Tailwind's `@custom-variant dark` (see `src/index.css`). The `dark` class on `<html>` is driven by `src/hooks/useTheme.ts` (states: `auto`/`light`/`dark`, persisted as `localStorage['raidy-theme']`, `auto` follows the OS). An inline FOUC script in `index.html` applies the theme before first paint. The header `ThemeToggle` (`src/components/common/ThemeToggle.tsx`) switches it.
+
+**Convention:** every color utility needs both a light default and a `dark:` override — e.g. `bg-white dark:bg-surface-800`, `text-slate-900 dark:text-white`, `text-slate-500 dark:text-slate-400`. A class with no `dark:` counterpart renders invisible in one theme. Saturated/semantic colors (`primary-*`, `capacity`/`overhead`/`parity`, explicit chart palette colors) read on both — leave them. Shared classes `.panel`/`.label`/`.accordion-trigger` already carry both variants. The PPTX export and chart captures follow the active theme (`exportPptx.ts` `BRAND`/`BRAND_LIGHT`, `captureChart.ts` background).

--- a/docs/adr/0002-intentional-divergences-from-vatlas.md
+++ b/docs/adr/0002-intentional-divergences-from-vatlas.md
@@ -19,6 +19,7 @@ That convergence is deliberate and ongoing. This ADR records the places where ra
 | **Charts** | Centralized ECharts (SVG renderer), bundle-gated | Recharts + D3-sankey + custom gauges | raidy's visuals (capacity waterfall/Sankey, speedometers, donut) predate the convergence and are not worth a rewrite. |
 | **Service worker / PWA** | `vite-plugin-pwa` (audited `src/sw.ts`) | none | Not a product requirement for raidy. |
 | **Supply-chain checks** | SheetJS CDN-tarball pin + SW privacy-guard envelope | telemetry denylist only | raidy has no `xlsx` dependency and no service worker, so those checks are inapplicable. |
+| **PPTX export theme** | Fixed "Midnight" deck — ignores the app theme | Follows the app's light/dark theme (light deck in light mode, dark deck in dark) | raidy users wanted the export to match what they see; charts are already theme-aware, so the deck adapts via a light/dark `BRAND` palette + theme-matched capture background. |
 
 ## Consequences
 

--- a/index.html
+++ b/index.html
@@ -24,6 +24,19 @@
     <!-- Content Security Policy for GitHub Pages (limited - no frame-ancestors support) -->
     <meta http-equiv="Content-Security-Policy"
           content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'">
+
+    <!-- FOUC-prevention: apply the saved/system theme (raidy-theme) before first paint.
+         Mirrors src/hooks/useTheme.ts. Inline is permitted by the CSP above. -->
+    <script>
+      (() => {
+        try {
+          const p = localStorage.getItem('raidy-theme')
+          const dark =
+            p === 'dark' || (p !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+          if (dark) document.documentElement.classList.add('dark')
+        } catch {}
+      })()
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raidy",
   "private": true,
-  "version": "1.6.1",
+  "version": "1.7.0",
   "type": "module",
   "description": "Browser-based simulator for modern storage infrastructure (RAID, ZFS, vSAN, S2D, Nutanix, Dell, NetApp, Ceph, Synology). 100% client-side.",
   "scripts": {

--- a/src/components/common/AccordionItem.tsx
+++ b/src/components/common/AccordionItem.tsx
@@ -12,7 +12,7 @@ interface AccordionItemProps {
 
 export function AccordionItem({ title, isOpen, onToggle, children }: AccordionItemProps) {
   return (
-    <div className="border-b border-surface-700 last:border-b-0">
+    <div className="border-b border-slate-200 dark:border-surface-700 last:border-b-0">
       <button type="button" onClick={onToggle} className="accordion-trigger">
         <span>{title}</span>
         <svg

--- a/src/components/common/FormControls.tsx
+++ b/src/components/common/FormControls.tsx
@@ -16,12 +16,15 @@ export function Label({ children, htmlFor, hint, tooltip }: LabelProps) {
   return (
     <div className="flex items-baseline justify-between">
       <div className="flex items-center gap-1.5">
-        <label htmlFor={htmlFor} className="block text-sm font-medium text-slate-300">
+        <label
+          htmlFor={htmlFor}
+          className="block text-sm font-medium text-slate-600 dark:text-slate-300"
+        >
           {children}
         </label>
         {tooltip && <InfoTooltip content={tooltip} />}
       </div>
-      {hint && <span className="text-xs text-slate-500">{hint}</span>}
+      {hint && <span className="text-xs text-slate-500 dark:text-slate-400">{hint}</span>}
     </div>
   )
 }
@@ -49,9 +52,11 @@ export function Slider({ id, value, min, max, step = 1, onChange, formatValue }:
         max={max}
         step={step}
         onChange={(e) => onChange(Number(e.target.value))}
-        className="flex-1 h-2 bg-surface-700 rounded-lg appearance-none cursor-pointer accent-primary-500"
+        className="flex-1 h-2 bg-slate-100 dark:bg-surface-700 rounded-lg appearance-none cursor-pointer accent-primary-500"
       />
-      <span className="w-16 text-right text-sm font-mono text-slate-300">{displayValue}</span>
+      <span className="w-16 text-right text-sm font-mono text-slate-600 dark:text-slate-300">
+        {displayValue}
+      </span>
     </div>
   )
 }
@@ -75,7 +80,7 @@ export function Select({ id, value, options, onChange }: SelectProps) {
       id={id}
       value={value}
       onChange={(e) => onChange(e.target.value)}
-      className="w-full px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+      className="w-full px-3 py-2 bg-slate-100 dark:bg-surface-700 border border-slate-200 dark:border-surface-600 rounded-lg text-slate-800 dark:text-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
     >
       {options.map((opt) => (
         <option key={opt.value} value={opt.value}>
@@ -96,7 +101,7 @@ interface ToggleProps {
 export function Toggle({ id, checked, onChange, label }: ToggleProps) {
   return (
     <label htmlFor={id} className="flex items-center justify-between cursor-pointer">
-      <span className="text-sm text-slate-300">{label}</span>
+      <span className="text-sm text-slate-600 dark:text-slate-300">{label}</span>
       <div className="relative">
         <input
           type="checkbox"
@@ -105,7 +110,7 @@ export function Toggle({ id, checked, onChange, label }: ToggleProps) {
           onChange={(e) => onChange(e.target.checked)}
           className="sr-only peer"
         />
-        <div className="w-10 h-5 bg-surface-600 rounded-full peer peer-checked:bg-primary-600 transition-colors" />
+        <div className="w-10 h-5 bg-slate-200 dark:bg-surface-600 rounded-full peer peer-checked:bg-primary-600 transition-colors" />
         <div className="absolute left-0.5 top-0.5 w-4 h-4 bg-white rounded-full transition-transform peer-checked:translate-x-5" />
       </div>
     </label>
@@ -133,9 +138,9 @@ export function NumberInput({ id, value, min, max, step = 1, onChange, suffix }:
         max={max}
         step={step}
         onChange={(e) => onChange(Number(e.target.value))}
-        className="flex-1 px-3 py-2 bg-surface-700 border border-surface-600 rounded-lg text-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+        className="flex-1 px-3 py-2 bg-slate-100 dark:bg-surface-700 border border-slate-200 dark:border-surface-600 rounded-lg text-slate-800 dark:text-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
       />
-      {suffix && <span className="text-sm text-slate-400">{suffix}</span>}
+      {suffix && <span className="text-sm text-slate-500 dark:text-slate-400">{suffix}</span>}
     </div>
   )
 }
@@ -148,7 +153,7 @@ interface SegmentedControlProps {
 
 export function SegmentedControl({ value, options, onChange }: SegmentedControlProps) {
   return (
-    <div className="flex bg-surface-700 rounded-lg p-1">
+    <div className="flex bg-slate-100 dark:bg-surface-700 rounded-lg p-1">
       {options.map((opt) => (
         <button
           key={opt.value}
@@ -157,7 +162,7 @@ export function SegmentedControl({ value, options, onChange }: SegmentedControlP
           className={`flex-1 px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
             value === opt.value
               ? 'bg-primary-600 text-white'
-              : 'text-slate-400 hover:text-slate-200'
+              : 'text-slate-500 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200'
           }`}
         >
           {opt.label}

--- a/src/components/common/InfoTooltip.tsx
+++ b/src/components/common/InfoTooltip.tsx
@@ -49,7 +49,7 @@ export function InfoTooltip({ content }: InfoTooltipProps) {
         onFocus={isTouch ? undefined : open}
         onBlur={isTouch ? undefined : close}
         aria-describedby={isOpen ? tooltipId : undefined}
-        className="text-slate-500 hover:text-primary-400 focus:text-primary-400 transition-colors focus:outline-none"
+        className="text-slate-500 dark:text-slate-400 hover:text-primary-400 focus:text-primary-400 transition-colors focus:outline-none"
         aria-label="Help"
       >
         <svg
@@ -72,7 +72,7 @@ export function InfoTooltip({ content }: InfoTooltipProps) {
         <div
           id={tooltipId}
           role="tooltip"
-          className="absolute left-0 top-full mt-1 z-50 bg-surface-700 border border-surface-600 rounded-lg p-3 shadow-lg text-xs text-slate-300 leading-relaxed max-w-xs sm:max-w-sm animate-tooltip-in"
+          className="absolute left-0 top-full mt-1 z-50 bg-slate-100 dark:bg-surface-700 border border-slate-200 dark:border-surface-600 rounded-lg p-3 shadow-lg text-xs text-slate-600 dark:text-slate-300 leading-relaxed max-w-xs sm:max-w-sm animate-tooltip-in"
         >
           {content}
         </div>

--- a/src/components/common/ThemeToggle.tsx
+++ b/src/components/common/ThemeToggle.tsx
@@ -1,0 +1,107 @@
+import { useTranslation } from 'react-i18next'
+import { type ThemePreference, useTheme } from '@/hooks/useTheme'
+
+const PREFERENCES: ReadonlyArray<ThemePreference> = ['auto', 'light', 'dark']
+
+const Glyph = ({ pref }: { pref: ThemePreference }) => {
+  switch (pref) {
+    case 'light':
+      // Sun
+      return (
+        <svg
+          role="img"
+          aria-hidden="true"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <title>Light</title>
+          <circle cx="12" cy="12" r="4" />
+          <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+        </svg>
+      )
+    case 'dark':
+      // Moon
+      return (
+        <svg
+          role="img"
+          aria-hidden="true"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <title>Dark</title>
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        </svg>
+      )
+    default:
+      // Auto = monitor
+      return (
+        <svg
+          role="img"
+          aria-hidden="true"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <title>Auto</title>
+          <rect x="3" y="4" width="18" height="12" rx="2" />
+          <path d="M8 20h8M12 16v4" />
+        </svg>
+      )
+  }
+}
+
+/**
+ * 3-state theme preference toggle (Auto / Light / Dark).
+ * Mirrors the language/unit switcher's `aria-pressed` button idiom.
+ */
+export function ThemeToggle() {
+  const { t } = useTranslation('common')
+  const { preference, setPreference } = useTheme()
+
+  return (
+    <fieldset
+      aria-label={t('theme.label')}
+      className="flex items-center gap-1 rounded-md border border-slate-200 bg-white p-0.5 text-xs dark:border-surface-700 dark:bg-surface-900"
+    >
+      <legend className="sr-only">{t('theme.label')}</legend>
+      {PREFERENCES.map((pref) => {
+        const active = preference === pref
+        return (
+          <button
+            key={pref}
+            type="button"
+            onClick={() => setPreference(pref)}
+            className={`flex items-center gap-1 rounded px-2 py-1 transition-colors ${
+              active
+                ? 'bg-primary-100 text-primary-900 dark:bg-primary-700 dark:text-slate-100'
+                : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'
+            }`}
+            aria-pressed={active}
+            aria-label={t(`theme.${pref}`)}
+            title={t(`theme.${pref}`)}
+          >
+            <Glyph pref={pref} />
+            <span>{t(`theme.${pref}`)}</span>
+          </button>
+        )
+      })}
+    </fieldset>
+  )
+}

--- a/src/components/guide/GuideView.tsx
+++ b/src/components/guide/GuideView.tsx
@@ -52,8 +52,8 @@ export function GuideView() {
     <main className="flex-1 overflow-y-auto p-6">
       <div className="max-w-3xl mx-auto">
         <div className="mb-6">
-          <h2 className="text-2xl font-bold text-white">{t('title')}</h2>
-          <p className="text-sm text-slate-400 mt-1">{t('subtitle')}</p>
+          <h2 className="text-2xl font-bold text-slate-900 dark:text-white">{t('title')}</h2>
+          <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">{t('subtitle')}</p>
         </div>
 
         <div className="panel">

--- a/src/components/guide/sections/CapacityGuide.tsx
+++ b/src/components/guide/sections/CapacityGuide.tsx
@@ -10,11 +10,13 @@ export function CapacityGuide() {
 
   return (
     <div className="space-y-4">
-      <p className="text-sm text-slate-300">{t('capacity.intro')}</p>
+      <p className="text-sm text-slate-600 dark:text-slate-300">{t('capacity.intro')}</p>
 
       <div className="space-y-2">
-        <h5 className="text-sm font-semibold text-slate-200">{t('capacity.waterfall.title')}</h5>
-        <ol className="space-y-1.5 text-sm text-slate-400">
+        <h5 className="text-sm font-semibold text-slate-800 dark:text-slate-200">
+          {t('capacity.waterfall.title')}
+        </h5>
+        <ol className="space-y-1.5 text-sm text-slate-500 dark:text-slate-400">
           <li className="flex items-start gap-2">
             <span className="text-primary-400 font-mono text-xs mt-0.5">1</span>
             <span>{t('capacity.waterfall.step1')}</span>
@@ -37,7 +39,9 @@ export function CapacityGuide() {
           </li>
           <li className="flex items-start gap-2">
             <span className="text-green-400 font-mono text-xs mt-0.5">=</span>
-            <span className="text-slate-200 font-medium">{t('capacity.waterfall.step6')}</span>
+            <span className="text-slate-800 dark:text-slate-200 font-medium">
+              {t('capacity.waterfall.step6')}
+            </span>
           </li>
           <li className="flex items-start gap-2">
             <span className="text-blue-400 font-mono text-xs mt-0.5">×</span>

--- a/src/components/guide/sections/PerformanceGuide.tsx
+++ b/src/components/guide/sections/PerformanceGuide.tsx
@@ -10,34 +10,44 @@ export function PerformanceGuide() {
 
   return (
     <div className="space-y-4">
-      <p className="text-sm text-slate-300">{t('performance.intro')}</p>
+      <p className="text-sm text-slate-600 dark:text-slate-300">{t('performance.intro')}</p>
 
       <div className="space-y-2">
-        <h5 className="text-sm font-semibold text-slate-200">{t('performance.chain.title')}</h5>
+        <h5 className="text-sm font-semibold text-slate-800 dark:text-slate-200">
+          {t('performance.chain.title')}
+        </h5>
         <div className="space-y-2">
-          <div className="flex items-start gap-3 p-2 bg-surface-700 rounded">
+          <div className="flex items-start gap-3 p-2 bg-slate-100 dark:bg-surface-700 rounded">
             <div className="w-6 h-6 bg-blue-500/20 rounded flex items-center justify-center flex-shrink-0">
               <span className="text-blue-400 text-xs font-bold">1</span>
             </div>
-            <p className="text-sm text-slate-400">{t('performance.chain.media')}</p>
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              {t('performance.chain.media')}
+            </p>
           </div>
-          <div className="flex items-start gap-3 p-2 bg-surface-700 rounded">
+          <div className="flex items-start gap-3 p-2 bg-slate-100 dark:bg-surface-700 rounded">
             <div className="w-6 h-6 bg-purple-500/20 rounded flex items-center justify-center flex-shrink-0">
               <span className="text-purple-400 text-xs font-bold">2</span>
             </div>
-            <p className="text-sm text-slate-400">{t('performance.chain.controller')}</p>
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              {t('performance.chain.controller')}
+            </p>
           </div>
-          <div className="flex items-start gap-3 p-2 bg-surface-700 rounded">
+          <div className="flex items-start gap-3 p-2 bg-slate-100 dark:bg-surface-700 rounded">
             <div className="w-6 h-6 bg-cyan-500/20 rounded flex items-center justify-center flex-shrink-0">
               <span className="text-cyan-400 text-xs font-bold">3</span>
             </div>
-            <p className="text-sm text-slate-400">{t('performance.chain.pcie')}</p>
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              {t('performance.chain.pcie')}
+            </p>
           </div>
-          <div className="flex items-start gap-3 p-2 bg-surface-700 rounded">
+          <div className="flex items-start gap-3 p-2 bg-slate-100 dark:bg-surface-700 rounded">
             <div className="w-6 h-6 bg-green-500/20 rounded flex items-center justify-center flex-shrink-0">
               <span className="text-green-400 text-xs font-bold">4</span>
             </div>
-            <p className="text-sm text-slate-400">{t('performance.chain.network')}</p>
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              {t('performance.chain.network')}
+            </p>
           </div>
         </div>
       </div>
@@ -46,7 +56,7 @@ export function PerformanceGuide() {
         <p className="text-xs text-orange-300">{t('performance.keyPoint')}</p>
       </div>
 
-      <p className="text-xs text-slate-500">{t('performance.alignment')}</p>
+      <p className="text-xs text-slate-500 dark:text-slate-400">{t('performance.alignment')}</p>
     </div>
   )
 }

--- a/src/components/guide/sections/PlatformGuide.tsx
+++ b/src/components/guide/sections/PlatformGuide.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next'
 function PlatformBlock({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <div className="space-y-2">
-      <h5 className="text-sm font-semibold text-slate-200">{title}</h5>
+      <h5 className="text-sm font-semibold text-slate-800 dark:text-slate-200">{title}</h5>
       {children}
     </div>
   )
@@ -19,47 +19,57 @@ export function PlatformGuide() {
 
   return (
     <div className="space-y-4">
-      <p className="text-sm text-slate-300">{t('platforms.intro')}</p>
+      <p className="text-sm text-slate-600 dark:text-slate-300">{t('platforms.intro')}</p>
 
       <div className="space-y-5">
         <PlatformBlock title={t('platforms.zfs.title')}>
-          <div className="space-y-1.5 text-sm text-slate-400">
+          <div className="space-y-1.5 text-sm text-slate-500 dark:text-slate-400">
             <p>{t('platforms.zfs.slop')}</p>
             <p>{t('platforms.zfs.ashift')}</p>
           </div>
-          <p className="text-xs text-slate-600 italic">{t('platforms.zfs.source')}</p>
+          <p className="text-xs text-slate-400 dark:text-slate-600 italic">
+            {t('platforms.zfs.source')}
+          </p>
         </PlatformBlock>
 
         <PlatformBlock title={t('platforms.vsanEsa.title')}>
-          <div className="space-y-1.5 text-sm text-slate-400">
+          <div className="space-y-1.5 text-sm text-slate-500 dark:text-slate-400">
             <p>{t('platforms.vsanEsa.adaptive')}</p>
             <p>{t('platforms.vsanEsa.nvme')}</p>
           </div>
-          <p className="text-xs text-slate-600 italic">{t('platforms.vsanEsa.source')}</p>
+          <p className="text-xs text-slate-400 dark:text-slate-600 italic">
+            {t('platforms.vsanEsa.source')}
+          </p>
         </PlatformBlock>
 
         <PlatformBlock title={t('platforms.ceph.title')}>
-          <div className="space-y-1.5 text-sm text-slate-400">
+          <div className="space-y-1.5 text-sm text-slate-500 dark:text-slate-400">
             <p>{t('platforms.ceph.nearfull')}</p>
             <p>{t('platforms.ceph.ec')}</p>
           </div>
-          <p className="text-xs text-slate-600 italic">{t('platforms.ceph.source')}</p>
+          <p className="text-xs text-slate-400 dark:text-slate-600 italic">
+            {t('platforms.ceph.source')}
+          </p>
         </PlatformBlock>
 
         <PlatformBlock title={t('platforms.s2d.title')}>
-          <div className="space-y-1.5 text-sm text-slate-400">
+          <div className="space-y-1.5 text-sm text-slate-500 dark:text-slate-400">
             <p>{t('platforms.s2d.reserve')}</p>
             <p>{t('platforms.s2d.map')}</p>
           </div>
-          <p className="text-xs text-slate-600 italic">{t('platforms.s2d.source')}</p>
+          <p className="text-xs text-slate-400 dark:text-slate-600 italic">
+            {t('platforms.s2d.source')}
+          </p>
         </PlatformBlock>
 
         <PlatformBlock title={t('platforms.nutanix.title')}>
-          <div className="space-y-1.5 text-sm text-slate-400">
+          <div className="space-y-1.5 text-sm text-slate-500 dark:text-slate-400">
             <p>{t('platforms.nutanix.ec')}</p>
             <p>{t('platforms.nutanix.overhead')}</p>
           </div>
-          <p className="text-xs text-slate-600 italic">{t('platforms.nutanix.source')}</p>
+          <p className="text-xs text-slate-400 dark:text-slate-600 italic">
+            {t('platforms.nutanix.source')}
+          </p>
         </PlatformBlock>
       </div>
     </div>

--- a/src/components/guide/sections/RaidGuide.tsx
+++ b/src/components/guide/sections/RaidGuide.tsx
@@ -10,50 +10,66 @@ export function RaidGuide() {
 
   return (
     <div className="space-y-4">
-      <p className="text-sm text-slate-300">{t('raid.intro')}</p>
+      <p className="text-sm text-slate-600 dark:text-slate-300">{t('raid.intro')}</p>
 
       <div className="space-y-2">
-        <h5 className="text-sm font-semibold text-slate-200">{t('raid.efficiency.title')}</h5>
+        <h5 className="text-sm font-semibold text-slate-800 dark:text-slate-200">
+          {t('raid.efficiency.title')}
+        </h5>
         <div className="space-y-1.5 text-sm">
-          <div className="flex items-center gap-2 text-slate-400">
+          <div className="flex items-center gap-2 text-slate-500 dark:text-slate-400">
             <span className="w-20 text-xs font-mono text-red-400">RAID 0</span>
             <span>{t('raid.efficiency.raid0')}</span>
           </div>
-          <div className="flex items-center gap-2 text-slate-400">
+          <div className="flex items-center gap-2 text-slate-500 dark:text-slate-400">
             <span className="w-20 text-xs font-mono text-yellow-400">RAID 1/10</span>
             <span>{t('raid.efficiency.raid1')}</span>
           </div>
-          <div className="flex items-center gap-2 text-slate-400">
+          <div className="flex items-center gap-2 text-slate-500 dark:text-slate-400">
             <span className="w-20 text-xs font-mono text-blue-400">RAID 5</span>
             <span>{t('raid.efficiency.raid5')}</span>
           </div>
-          <div className="flex items-center gap-2 text-slate-400">
+          <div className="flex items-center gap-2 text-slate-500 dark:text-slate-400">
             <span className="w-20 text-xs font-mono text-purple-400">RAID 6</span>
             <span>{t('raid.efficiency.raid6')}</span>
           </div>
         </div>
-        <p className="text-xs text-slate-500 italic">{t('raid.efficiency.example')}</p>
+        <p className="text-xs text-slate-500 dark:text-slate-400 italic">
+          {t('raid.efficiency.example')}
+        </p>
       </div>
 
       <div className="space-y-2">
-        <h5 className="text-sm font-semibold text-slate-200">{t('raid.writePenalty.title')}</h5>
-        <p className="text-sm text-slate-400">{t('raid.writePenalty.intro')}</p>
+        <h5 className="text-sm font-semibold text-slate-800 dark:text-slate-200">
+          {t('raid.writePenalty.title')}
+        </h5>
+        <p className="text-sm text-slate-500 dark:text-slate-400">{t('raid.writePenalty.intro')}</p>
         <div className="grid grid-cols-1 gap-2 text-sm">
-          <div className="p-2 bg-surface-700 rounded">
+          <div className="p-2 bg-slate-100 dark:bg-surface-700 rounded">
             <span className="text-orange-400 font-mono text-xs">4x</span>
-            <span className="text-slate-400 ml-2">{t('raid.writePenalty.raid5')}</span>
+            <span className="text-slate-500 dark:text-slate-400 ml-2">
+              {t('raid.writePenalty.raid5')}
+            </span>
           </div>
-          <div className="p-2 bg-surface-700 rounded">
+          <div className="p-2 bg-slate-100 dark:bg-surface-700 rounded">
             <span className="text-red-400 font-mono text-xs">6x</span>
-            <span className="text-slate-400 ml-2">{t('raid.writePenalty.raid6')}</span>
+            <span className="text-slate-500 dark:text-slate-400 ml-2">
+              {t('raid.writePenalty.raid6')}
+            </span>
           </div>
-          <div className="p-2 bg-surface-700 rounded">
+          <div className="p-2 bg-slate-100 dark:bg-surface-700 rounded">
             <span className="text-yellow-400 font-mono text-xs">2x</span>
-            <span className="text-slate-400 ml-2">{t('raid.writePenalty.mirror')}</span>
+            <span className="text-slate-500 dark:text-slate-400 ml-2">
+              {t('raid.writePenalty.mirror')}
+            </span>
           </div>
         </div>
-        <p className="text-xs text-slate-500">{t('raid.writePenalty.sequential')}</p>
-        <p className="text-xs text-slate-600 italic">{t('raid.writePenalty.sources')}</p>
+        <p className="text-xs text-slate-500 dark:text-slate-400">
+          {t('raid.writePenalty.sequential')}
+        </p>
+        <p className="text-xs text-slate-400 dark:text-slate-600 italic">
+          {t('raid.writePenalty.sources')}
+        </p>
       </div>
     </div>
   )

--- a/src/components/guide/sections/ResilienceGuide.tsx
+++ b/src/components/guide/sections/ResilienceGuide.tsx
@@ -10,11 +10,13 @@ export function ResilienceGuide() {
 
   return (
     <div className="space-y-4">
-      <p className="text-sm text-slate-300">{t('resilience.intro')}</p>
+      <p className="text-sm text-slate-600 dark:text-slate-300">{t('resilience.intro')}</p>
 
       <div className="space-y-2">
-        <h5 className="text-sm font-semibold text-slate-200">{t('resilience.process.title')}</h5>
-        <ol className="space-y-1.5 text-sm text-slate-400">
+        <h5 className="text-sm font-semibold text-slate-800 dark:text-slate-200">
+          {t('resilience.process.title')}
+        </h5>
+        <ol className="space-y-1.5 text-sm text-slate-500 dark:text-slate-400">
           {(['step1', 'step2', 'step3', 'step4', 'step5', 'step6'] as const).map((step) => (
             <li key={step} className="flex items-start gap-2">
               <span className="text-primary-400 font-mono text-xs mt-0.5">
@@ -27,15 +29,19 @@ export function ResilienceGuide() {
       </div>
 
       <div className="space-y-2">
-        <h5 className="text-sm font-semibold text-slate-200">{t('resilience.ure.title')}</h5>
-        <p className="text-sm text-slate-400">{t('resilience.ure.description')}</p>
+        <h5 className="text-sm font-semibold text-slate-800 dark:text-slate-200">
+          {t('resilience.ure.title')}
+        </h5>
+        <p className="text-sm text-slate-500 dark:text-slate-400">
+          {t('resilience.ure.description')}
+        </p>
       </div>
 
       <div className="p-3 bg-yellow-900/20 border border-yellow-700/30 rounded-lg">
         <p className="text-xs text-yellow-300">{t('resilience.keyPoint')}</p>
       </div>
 
-      <p className="text-xs text-slate-600 italic">{t('resilience.sources')}</p>
+      <p className="text-xs text-slate-400 dark:text-slate-600 italic">{t('resilience.sources')}</p>
     </div>
   )
 }

--- a/src/components/guide/sections/SustainabilityGuide.tsx
+++ b/src/components/guide/sections/SustainabilityGuide.tsx
@@ -10,34 +10,48 @@ export function SustainabilityGuide() {
 
   return (
     <div className="space-y-4">
-      <p className="text-sm text-slate-300">{t('sustainability.intro')}</p>
+      <p className="text-sm text-slate-600 dark:text-slate-300">{t('sustainability.intro')}</p>
 
       <div className="space-y-2">
-        <h5 className="text-sm font-semibold text-slate-200">{t('sustainability.pue.title')}</h5>
-        <p className="text-sm text-slate-400">{t('sustainability.pue.description')}</p>
-        <div className="p-2 bg-surface-700 rounded font-mono text-xs text-green-400">
+        <h5 className="text-sm font-semibold text-slate-800 dark:text-slate-200">
+          {t('sustainability.pue.title')}
+        </h5>
+        <p className="text-sm text-slate-500 dark:text-slate-400">
+          {t('sustainability.pue.description')}
+        </p>
+        <div className="p-2 bg-slate-100 dark:bg-surface-700 rounded font-mono text-xs text-green-400">
           {t('sustainability.pue.formula')}
         </div>
-        <p className="text-xs text-slate-500">{t('sustainability.pue.examples')}</p>
+        <p className="text-xs text-slate-500 dark:text-slate-400">
+          {t('sustainability.pue.examples')}
+        </p>
       </div>
 
       <div className="space-y-2">
-        <h5 className="text-sm font-semibold text-slate-200">{t('sustainability.co2.title')}</h5>
-        <p className="text-sm text-slate-400">{t('sustainability.co2.description')}</p>
-        <div className="p-2 bg-surface-700 rounded text-xs text-slate-300">
+        <h5 className="text-sm font-semibold text-slate-800 dark:text-slate-200">
+          {t('sustainability.co2.title')}
+        </h5>
+        <p className="text-sm text-slate-500 dark:text-slate-400">
+          {t('sustainability.co2.description')}
+        </p>
+        <div className="p-2 bg-slate-100 dark:bg-surface-700 rounded text-xs text-slate-600 dark:text-slate-300">
           {t('sustainability.co2.comparison')}
         </div>
       </div>
 
       <div className="space-y-2">
-        <h5 className="text-sm font-semibold text-slate-200">
+        <h5 className="text-sm font-semibold text-slate-800 dark:text-slate-200">
           {t('sustainability.endurance.title')}
         </h5>
-        <p className="text-sm text-slate-400">{t('sustainability.endurance.description')}</p>
-        <div className="p-2 bg-surface-700 rounded font-mono text-xs text-cyan-400">
+        <p className="text-sm text-slate-500 dark:text-slate-400">
+          {t('sustainability.endurance.description')}
+        </p>
+        <div className="p-2 bg-slate-100 dark:bg-surface-700 rounded font-mono text-xs text-cyan-400">
           {t('sustainability.endurance.formula')}
         </div>
-        <p className="text-xs text-slate-500 italic">{t('sustainability.endurance.example')}</p>
+        <p className="text-xs text-slate-500 dark:text-slate-400 italic">
+          {t('sustainability.endurance.example')}
+        </p>
       </div>
     </div>
   )

--- a/src/components/inputs/AdvancedPanel.tsx
+++ b/src/components/inputs/AdvancedPanel.tsx
@@ -92,8 +92,8 @@ export function AdvancedPanel() {
         topology.type !== 'objectscale' &&
         topology.type !== 'powerflex' &&
         topology.type !== 'nutanix' && (
-          <div className="space-y-4 pt-4 border-t border-surface-700">
-            <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
+          <div className="space-y-4 pt-4 border-t border-slate-200 dark:border-surface-700">
+            <h4 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
               {t('dataEfficiency.title')}
             </h4>
 
@@ -139,8 +139,8 @@ export function AdvancedPanel() {
         )}
 
       {/* Network & Bus Section */}
-      <div className="space-y-4 pt-4 border-t border-surface-700">
-        <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
+      <div className="space-y-4 pt-4 border-t border-slate-200 dark:border-surface-700">
+        <h4 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
           {t('network.title')}
         </h4>
 
@@ -183,8 +183,8 @@ export function AdvancedPanel() {
       </div>
 
       {/* Controller / HBA Section */}
-      <div className="space-y-4 pt-4 border-t border-surface-700">
-        <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
+      <div className="space-y-4 pt-4 border-t border-slate-200 dark:border-surface-700">
+        <h4 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
           {needsHba ? t('pcie.title') : t('controller.title')}
         </h4>
 
@@ -199,14 +199,16 @@ export function AdvancedPanel() {
             onChange={(v) => setControllerOptions({ controller: v as ControllerType })}
           />
           {selectedController && (
-            <div className="grid grid-cols-2 gap-2 mt-2 text-xs text-slate-400">
+            <div className="grid grid-cols-2 gap-2 mt-2 text-xs text-slate-500 dark:text-slate-400">
               <div>
                 {t('controller.maxIops')}:{' '}
-                <span className="text-slate-300">{selectedController.iops.toLocaleString()}</span>
+                <span className="text-slate-600 dark:text-slate-300">
+                  {selectedController.iops.toLocaleString()}
+                </span>
               </div>
               <div>
                 {t('controller.maxThroughput')}:{' '}
-                <span className="text-slate-300">
+                <span className="text-slate-600 dark:text-slate-300">
                   {selectedController.throughputMBs.toLocaleString()} MB/s
                 </span>
               </div>
@@ -219,8 +221,8 @@ export function AdvancedPanel() {
       </div>
 
       {/* Power & Sustainability Section */}
-      <div className="space-y-4 pt-4 border-t border-surface-700">
-        <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
+      <div className="space-y-4 pt-4 border-t border-slate-200 dark:border-surface-700">
+        <h4 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
           {t('power.title')}
         </h4>
 
@@ -242,8 +244,8 @@ export function AdvancedPanel() {
       </div>
 
       {/* Capacity Management Section */}
-      <div className="space-y-4 pt-4 border-t border-surface-700">
-        <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
+      <div className="space-y-4 pt-4 border-t border-slate-200 dark:border-surface-700">
+        <h4 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
           {t('capacityManagement.title')}
         </h4>
 
@@ -271,8 +273,8 @@ export function AdvancedPanel() {
       </div>
 
       {/* Filesystem & Backup Section */}
-      <div className="space-y-4 pt-4 border-t border-surface-700">
-        <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
+      <div className="space-y-4 pt-4 border-t border-slate-200 dark:border-surface-700">
+        <h4 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
           {t('filesystem.title')}
         </h4>
 

--- a/src/components/inputs/DrivePropertiesPanel.tsx
+++ b/src/components/inputs/DrivePropertiesPanel.tsx
@@ -16,8 +16,8 @@ const drives = drivesData as Record<string, Drive>
 function PropertyRow({ label, value }: { label: string; value: React.ReactNode }) {
   return (
     <div className="flex justify-between py-1">
-      <span className="text-slate-400 text-sm">{label}</span>
-      <span className="text-white text-sm font-medium">{value}</span>
+      <span className="text-slate-500 dark:text-slate-400 text-sm">{label}</span>
+      <span className="text-slate-900 dark:text-white text-sm font-medium">{value}</span>
     </div>
   )
 }

--- a/src/components/inputs/HardwarePanel.tsx
+++ b/src/components/inputs/HardwarePanel.tsx
@@ -139,7 +139,7 @@ export function HardwarePanel() {
         <Label tooltip={th('hardware.connectivity')}>{t('connectivity.label')}</Label>
         {constraint === 'nvme_only' ? (
           <>
-            <div className="px-3 py-2 bg-surface-700 rounded-lg text-sm text-slate-300">
+            <div className="px-3 py-2 bg-slate-100 dark:bg-surface-700 rounded-lg text-sm text-slate-600 dark:text-slate-300">
               {t('connectivity.nvme')}
             </div>
             {reasonKey && <p className="text-xs text-amber-500">{t(reasonKey)}</p>}
@@ -182,27 +182,29 @@ export function HardwarePanel() {
         </Label>
         <Select id="drive-select" value={driveId} options={driveOptions} onChange={setDriveId} />
         {selectedDrive && (
-          <div className="grid grid-cols-2 gap-2 mt-2 text-xs text-slate-400">
+          <div className="grid grid-cols-2 gap-2 mt-2 text-xs text-slate-500 dark:text-slate-400">
             <div>
               {t('properties.type')}:{' '}
-              <span className="text-slate-300">
+              <span className="text-slate-600 dark:text-slate-300">
                 {selectedDrive.type}
                 {selectedDrive.formFactor ? ` (${selectedDrive.formFactor})` : ''}
               </span>
             </div>
             <div>
               {t('properties.cost')}:{' '}
-              <span className="text-slate-300">{formatPrice(selectedDrive.cost_usd)}</span>
+              <span className="text-slate-600 dark:text-slate-300">
+                {formatPrice(selectedDrive.cost_usd)}
+              </span>
             </div>
             <div>
               {t('properties.readIops').replace(' IOPS', '')}:{' '}
-              <span className="text-slate-300">
+              <span className="text-slate-600 dark:text-slate-300">
                 {selectedDrive.performance.iops_read.toLocaleString()} IOPS
               </span>
             </div>
             <div>
               {t('properties.writeIops').replace(' IOPS', '')}:{' '}
-              <span className="text-slate-300">
+              <span className="text-slate-600 dark:text-slate-300">
                 {selectedDrive.performance.iops_write.toLocaleString()} IOPS
               </span>
             </div>
@@ -251,12 +253,16 @@ export function HardwarePanel() {
       </div>
 
       {/* Summary */}
-      <div className="pt-3 border-t border-surface-700">
+      <div className="pt-3 border-t border-slate-200 dark:border-surface-700">
         <div className="grid grid-cols-2 gap-2 text-sm">
-          <div className="text-slate-400">{t('summary.rawCapacity')}:</div>
-          <div className="text-right font-medium text-white">{formatBytes(totalRawCapacity)}</div>
-          <div className="text-slate-400">{t('summary.hardwareCost')}:</div>
-          <div className="text-right font-medium text-white">{formatPrice(totalCost)}</div>
+          <div className="text-slate-500 dark:text-slate-400">{t('summary.rawCapacity')}:</div>
+          <div className="text-right font-medium text-slate-900 dark:text-white">
+            {formatBytes(totalRawCapacity)}
+          </div>
+          <div className="text-slate-500 dark:text-slate-400">{t('summary.hardwareCost')}:</div>
+          <div className="text-right font-medium text-slate-900 dark:text-white">
+            {formatPrice(totalCost)}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/inputs/TieringPanel.tsx
+++ b/src/components/inputs/TieringPanel.tsx
@@ -149,7 +149,7 @@ export function TieringPanel({
       )}
 
       {/* Fast Tier Section */}
-      <div className="space-y-3 p-3 bg-surface-800 rounded-lg">
+      <div className="space-y-3 p-3 bg-white dark:bg-surface-800 rounded-lg">
         <h5 className="text-sm font-medium text-blue-400">{labels.fastTier}</h5>
         <p className="text-xs text-slate-500">{labels.fastTierHint}</p>
 
@@ -180,15 +180,17 @@ export function TieringPanel({
         </div>
 
         {selectedFastDrive && (
-          <div className="text-xs text-slate-400">
+          <div className="text-xs text-slate-500 dark:text-slate-400">
             {t('tiering.fastTierCapacity')}:{' '}
-            <span className="text-white font-medium">{formatBytes(totalFastCapacity)}</span>
+            <span className="text-slate-900 dark:text-white font-medium">
+              {formatBytes(totalFastCapacity)}
+            </span>
           </div>
         )}
       </div>
 
       {/* Capacity Tier Section */}
-      <div className="space-y-3 p-3 bg-surface-800 rounded-lg">
+      <div className="space-y-3 p-3 bg-white dark:bg-surface-800 rounded-lg">
         <h5 className="text-sm font-medium text-emerald-400">{labels.capacityTier}</h5>
         <p className="text-xs text-slate-500">{labels.capacityTierHint}</p>
 
@@ -221,9 +223,11 @@ export function TieringPanel({
         </div>
 
         {selectedCapacityDrive && (
-          <div className="text-xs text-slate-400">
+          <div className="text-xs text-slate-500 dark:text-slate-400">
             {t('tiering.capacityTier')}:{' '}
-            <span className="text-white font-medium">{formatBytes(totalCapacityCapacity)}</span>
+            <span className="text-slate-900 dark:text-white font-medium">
+              {formatBytes(totalCapacityCapacity)}
+            </span>
           </div>
         )}
       </div>
@@ -265,20 +269,20 @@ export function TieringPanel({
       )}
 
       {/* Summary */}
-      <div className="pt-3 border-t border-surface-700">
+      <div className="pt-3 border-t border-slate-200 dark:border-surface-700">
         <div className="grid grid-cols-2 gap-2 text-sm">
-          <div className="text-slate-400">{t('tiering.totalDrivesLabel')}:</div>
-          <div className="text-right font-medium text-white">
+          <div className="text-slate-500 dark:text-slate-400">{t('tiering.totalDrivesLabel')}:</div>
+          <div className="text-right font-medium text-slate-900 dark:text-white">
             {totalFastDrives + totalCapacityDrives}
           </div>
-          <div className="text-slate-400">{t('tiering.cacheRatio')}:</div>
+          <div className="text-slate-500 dark:text-slate-400">{t('tiering.cacheRatio')}:</div>
           <div className={`text-right font-medium ${ratioColor}`}>
             {cacheRatio.toFixed(1)}%
             <span className="text-xs ml-1">
               ({ratioStatus === 'optimal' ? '✓' : ratioStatus === 'low' ? '↓' : '↑'})
             </span>
           </div>
-          <div className="text-slate-400">{t('tiering.recommended')}:</div>
+          <div className="text-slate-500 dark:text-slate-400">{t('tiering.recommended')}:</div>
           <div className="text-right text-xs text-slate-500">10-20%</div>
         </div>
       </div>

--- a/src/components/inputs/WorkloadPanel.tsx
+++ b/src/components/inputs/WorkloadPanel.tsx
@@ -184,7 +184,7 @@ export function WorkloadPanel() {
       </div>
 
       {/* Workload Presets */}
-      <div className="pt-3 border-t border-surface-700">
+      <div className="pt-3 border-t border-slate-200 dark:border-surface-700">
         <Label>{t('presets.label')}</Label>
         <div className="grid grid-cols-2 gap-2 mt-2">
           <button
@@ -194,7 +194,7 @@ export function WorkloadPanel() {
               setRandomPercent(80)
               setBlockSize('8K')
             }}
-            className="px-3 py-2 text-xs bg-surface-700 hover:bg-surface-600 rounded-lg text-slate-300 transition-colors"
+            className="px-3 py-2 text-xs bg-slate-100 dark:bg-surface-700 hover:bg-slate-200 dark:hover:bg-surface-600 rounded-lg text-slate-600 dark:text-slate-300 transition-colors"
           >
             {t('presets.database')}
           </button>
@@ -205,7 +205,7 @@ export function WorkloadPanel() {
               setRandomPercent(20)
               setBlockSize('128K')
             }}
-            className="px-3 py-2 text-xs bg-surface-700 hover:bg-surface-600 rounded-lg text-slate-300 transition-colors"
+            className="px-3 py-2 text-xs bg-slate-100 dark:bg-surface-700 hover:bg-slate-200 dark:hover:bg-surface-600 rounded-lg text-slate-600 dark:text-slate-300 transition-colors"
           >
             {t('presets.fileServer')}
           </button>
@@ -216,7 +216,7 @@ export function WorkloadPanel() {
               setRandomPercent(10)
               setBlockSize('1M')
             }}
-            className="px-3 py-2 text-xs bg-surface-700 hover:bg-surface-600 rounded-lg text-slate-300 transition-colors"
+            className="px-3 py-2 text-xs bg-slate-100 dark:bg-surface-700 hover:bg-slate-200 dark:hover:bg-surface-600 rounded-lg text-slate-600 dark:text-slate-300 transition-colors"
           >
             {t('presets.videoStreaming')}
           </button>
@@ -227,7 +227,7 @@ export function WorkloadPanel() {
               setRandomPercent(5)
               setBlockSize('1M')
             }}
-            className="px-3 py-2 text-xs bg-surface-700 hover:bg-surface-600 rounded-lg text-slate-300 transition-colors"
+            className="px-3 py-2 text-xs bg-slate-100 dark:bg-surface-700 hover:bg-slate-200 dark:hover:bg-surface-600 rounded-lg text-slate-600 dark:text-slate-300 transition-colors"
           >
             {t('presets.backup')}
           </button>

--- a/src/components/inputs/topology-options/CephOptionsPanel.tsx
+++ b/src/components/inputs/topology-options/CephOptionsPanel.tsx
@@ -27,8 +27,8 @@ export function CephOptionsPanel() {
   const { cephOptions, serverCount, setCephOptions } = useConfigStore()
 
   return (
-    <div className="space-y-4 pt-3 border-t border-surface-700">
-      <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
+    <div className="space-y-4 pt-3 border-t border-slate-200 dark:border-surface-700">
+      <h4 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
         {t('ceph.title')}
       </h4>
 

--- a/src/components/inputs/topology-options/DellOptionsPanel.tsx
+++ b/src/components/inputs/topology-options/DellOptionsPanel.tsx
@@ -46,43 +46,45 @@ export function DellOptionsPanel({ topology }: DellOptionsPanelProps) {
   // PowerVault ME5 Options
   if (topology.type === 'powervault') {
     return (
-      <div className="space-y-4 pt-3 border-t border-surface-700">
-        <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
+      <div className="space-y-4 pt-3 border-t border-slate-200 dark:border-surface-700">
+        <h4 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
           {t('powervault.title')}
         </h4>
 
         {/* Show mode description based on selected topology level */}
-        <div className="p-3 bg-surface-800 rounded-lg text-xs text-slate-400">
+        <div className="p-3 bg-white dark:bg-surface-800 rounded-lg text-xs text-slate-500 dark:text-slate-400">
           {topology.level === 'powervault_raid1' && (
             <p>
-              <strong className="text-slate-300">RAID 1:</strong> 2-way mirror with 50% storage
-              efficiency. Simple, fast rebuilds. Best for boot volumes and small deployments.
+              <strong className="text-slate-600 dark:text-slate-300">RAID 1:</strong> 2-way mirror
+              with 50% storage efficiency. Simple, fast rebuilds. Best for boot volumes and small
+              deployments.
             </p>
           )}
           {topology.level === 'powervault_raid5' && (
             <p>
-              <strong className="text-slate-300">RAID 5:</strong> Single distributed parity with
-              (n-1)/n efficiency. 4x write penalty. Not recommended for write-intensive workloads.
+              <strong className="text-slate-600 dark:text-slate-300">RAID 5:</strong> Single
+              distributed parity with (n-1)/n efficiency. 4x write penalty. Not recommended for
+              write-intensive workloads.
             </p>
           )}
           {topology.level === 'powervault_raid6' && (
             <p>
-              <strong className="text-slate-300">RAID 6:</strong> Dual distributed parity with
-              (n-2)/n efficiency. 6x write penalty. Better data protection for large capacity
-              drives.
+              <strong className="text-slate-600 dark:text-slate-300">RAID 6:</strong> Dual
+              distributed parity with (n-2)/n efficiency. 6x write penalty. Better data protection
+              for large capacity drives.
             </p>
           )}
           {topology.level === 'powervault_raid10' && (
             <p>
-              <strong className="text-slate-300">RAID 10:</strong> Mirrored stripes with 50%
-              efficiency. Best random IOPS performance. Ideal for databases.
+              <strong className="text-slate-600 dark:text-slate-300">RAID 10:</strong> Mirrored
+              stripes with 50% efficiency. Best random IOPS performance. Ideal for databases.
             </p>
           )}
           {topology.level === 'powervault_adapt' && (
             <p>
-              <strong className="text-slate-300">ADAPT:</strong> Distributed RAID with ~87%
-              efficiency. Spare capacity distributed across all drives. Fastest rebuilds (8-10x
-              faster). Requires 12-128 drives.
+              <strong className="text-slate-600 dark:text-slate-300">ADAPT:</strong> Distributed
+              RAID with ~87% efficiency. Spare capacity distributed across all drives. Fastest
+              rebuilds (8-10x faster). Requires 12-128 drives.
             </p>
           )}
         </div>
@@ -166,8 +168,8 @@ export function DellOptionsPanel({ topology }: DellOptionsPanelProps) {
   // ObjectScale Options
   if (topology.type === 'objectscale') {
     return (
-      <div className="space-y-4 pt-3 border-t border-surface-700">
-        <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
+      <div className="space-y-4 pt-3 border-t border-slate-200 dark:border-surface-700">
+        <h4 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
           {t('objectscale.title')}
         </h4>
 
@@ -250,8 +252,8 @@ export function DellOptionsPanel({ topology }: DellOptionsPanelProps) {
   // PowerStore Options
   if (topology.type === 'powerstore') {
     return (
-      <div className="space-y-4 pt-3 border-t border-surface-700">
-        <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
+      <div className="space-y-4 pt-3 border-t border-slate-200 dark:border-surface-700">
+        <h4 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
           {t('powerstore.title')}
         </h4>
 
@@ -372,8 +374,8 @@ export function DellOptionsPanel({ topology }: DellOptionsPanelProps) {
   // PowerScale Options
   if (topology.type === 'powerscale') {
     return (
-      <div className="space-y-4 pt-3 border-t border-surface-700">
-        <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
+      <div className="space-y-4 pt-3 border-t border-slate-200 dark:border-surface-700">
+        <h4 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
           {t('powerscale.title')}
         </h4>
 
@@ -459,29 +461,33 @@ export function DellOptionsPanel({ topology }: DellOptionsPanelProps) {
   // PowerFlex Options
   if (topology.type === 'powerflex') {
     return (
-      <div className="space-y-4 pt-3 border-t border-surface-700">
-        <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
+      <div className="space-y-4 pt-3 border-t border-slate-200 dark:border-surface-700">
+        <h4 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
           {t('powerflex.title')}
         </h4>
 
         {/* Show mode description based on selected topology level */}
-        <div className="p-3 bg-surface-800 rounded-lg text-xs text-slate-400">
+        <div className="p-3 bg-white dark:bg-surface-800 rounded-lg text-xs text-slate-500 dark:text-slate-400">
           {topology.level.includes('medium') && (
             <p>
-              <strong className="text-slate-300">Medium Granularity (1MB):</strong> Standard mode
-              with lower metadata overhead. Supports 2-way and 3-way mirroring.
+              <strong className="text-slate-600 dark:text-slate-300">
+                Medium Granularity (1MB):
+              </strong>{' '}
+              Standard mode with lower metadata overhead. Supports 2-way and 3-way mirroring.
             </p>
           )}
           {topology.level.includes('fine') && (
             <p>
-              <strong className="text-slate-300">Fine Granularity (8KB):</strong> Better for small
-              random I/O. Only supports 2-way mirroring. 12-15% metadata overhead.
+              <strong className="text-slate-600 dark:text-slate-300">
+                Fine Granularity (8KB):
+              </strong>{' '}
+              Better for small random I/O. Only supports 2-way mirroring. 12-15% metadata overhead.
             </p>
           )}
           {topology.level.includes('ec_') && (
             <p>
-              <strong className="text-slate-300">Erasure Coding:</strong> Higher capacity efficiency
-              but ~30% lower IOPS due to CPU overhead. Requires PowerFlex 4.5+.
+              <strong className="text-slate-600 dark:text-slate-300">Erasure Coding:</strong> Higher
+              capacity efficiency but ~30% lower IOPS due to CPU overhead. Requires PowerFlex 4.5+.
             </p>
           )}
         </div>

--- a/src/components/inputs/topology-options/NetAppOptionsPanel.tsx
+++ b/src/components/inputs/topology-options/NetAppOptionsPanel.tsx
@@ -22,8 +22,8 @@ export function NetAppOptionsPanel() {
   const { netAppOptions, setNetAppOptions } = useConfigStore()
 
   return (
-    <div className="space-y-4 pt-3 border-t border-surface-700">
-      <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
+    <div className="space-y-4 pt-3 border-t border-slate-200 dark:border-surface-700">
+      <h4 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
         {t('netapp.title')}
       </h4>
 

--- a/src/components/inputs/topology-options/NutanixOptionsPanel.tsx
+++ b/src/components/inputs/topology-options/NutanixOptionsPanel.tsx
@@ -23,35 +23,35 @@ export function NutanixOptionsPanel({ topology }: NutanixOptionsPanelProps) {
   const { nutanixOptions, setNutanixOptions } = useConfigStore()
 
   return (
-    <div className="space-y-4 pt-3 border-t border-surface-700">
-      <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
+    <div className="space-y-4 pt-3 border-t border-slate-200 dark:border-surface-700">
+      <h4 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
         {t('nutanix.title')}
       </h4>
 
       {/* Show mode description based on selected topology level */}
-      <div className="p-3 bg-surface-800 rounded-lg text-xs text-slate-400">
+      <div className="p-3 bg-white dark:bg-surface-800 rounded-lg text-xs text-slate-500 dark:text-slate-400">
         {topology.level === 'nutanix_rf2' && (
           <p>
-            <strong className="text-slate-300">RF2:</strong> 2 copies of data, 50% storage
-            efficiency. Tolerates single node failure.
+            <strong className="text-slate-600 dark:text-slate-300">RF2:</strong> 2 copies of data,
+            50% storage efficiency. Tolerates single node failure.
           </p>
         )}
         {topology.level === 'nutanix_rf3' && (
           <p>
-            <strong className="text-slate-300">RF3:</strong> 3 copies of data, 33% storage
-            efficiency. Tolerates dual node failure.
+            <strong className="text-slate-600 dark:text-slate-300">RF3:</strong> 3 copies of data,
+            33% storage efficiency. Tolerates dual node failure.
           </p>
         )}
         {topology.level === 'nutanix_ec_rf2' && (
           <p>
-            <strong className="text-slate-300">EC-X (RF2):</strong> Erasure coding 4:1 for cold
-            data, ~75% efficiency. Hot data remains RF2.
+            <strong className="text-slate-600 dark:text-slate-300">EC-X (RF2):</strong> Erasure
+            coding 4:1 for cold data, ~75% efficiency. Hot data remains RF2.
           </p>
         )}
         {topology.level === 'nutanix_ec_rf3' && (
           <p>
-            <strong className="text-slate-300">EC-X (RF3):</strong> Erasure coding 6:2 for cold
-            data, ~75% efficiency. Hot data remains RF3.
+            <strong className="text-slate-600 dark:text-slate-300">EC-X (RF3):</strong> Erasure
+            coding 6:2 for cold data, ~75% efficiency. Hot data remains RF3.
           </p>
         )}
       </div>

--- a/src/components/inputs/topology-options/S2dOptionsPanel.tsx
+++ b/src/components/inputs/topology-options/S2dOptionsPanel.tsx
@@ -25,8 +25,8 @@ export function S2dOptionsPanel({ topology }: S2dOptionsPanelProps) {
   const { s2dOptions, serverCount, setS2DOptions } = useConfigStore()
 
   return (
-    <div className="space-y-4 pt-3 border-t border-surface-700">
-      <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
+    <div className="space-y-4 pt-3 border-t border-slate-200 dark:border-surface-700">
+      <h4 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
         {t('s2d.title')}
       </h4>
 

--- a/src/components/inputs/topology-options/SynologyOptionsPanel.tsx
+++ b/src/components/inputs/topology-options/SynologyOptionsPanel.tsx
@@ -18,8 +18,8 @@ export function SynologyOptionsPanel() {
   const { synologyOptions, setSynologyOptions } = useConfigStore()
 
   return (
-    <div className="space-y-4 pt-3 border-t border-surface-700">
-      <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
+    <div className="space-y-4 pt-3 border-t border-slate-200 dark:border-surface-700">
+      <h4 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
         {t('synology.title')}
       </h4>
 

--- a/src/components/inputs/topology-options/VsanOptionsPanel.tsx
+++ b/src/components/inputs/topology-options/VsanOptionsPanel.tsx
@@ -26,58 +26,59 @@ export function VsanOptionsPanel({ topology }: VsanOptionsPanelProps) {
   const isEsa = topology.type === 'vsan_esa'
 
   return (
-    <div className="space-y-4 pt-3 border-t border-surface-700">
-      <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
+    <div className="space-y-4 pt-3 border-t border-slate-200 dark:border-surface-700">
+      <h4 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
         {isOsa ? t('vsanOsa.title') : t('vsanEsa.title')}
       </h4>
 
       {/* Configuration info box */}
-      <div className="p-3 bg-surface-800 rounded-lg text-xs text-slate-400">
+      <div className="p-3 bg-white dark:bg-surface-800 rounded-lg text-xs text-slate-500 dark:text-slate-400">
         {isOsa && topology.level === 'vsan_osa_raid1' && (
           <p>
-            <strong className="text-slate-300">RAID-1 FTT=1:</strong> 2-way mirror, requires minimum
-            3 hosts. 50% storage efficiency. Best read performance.
+            <strong className="text-slate-600 dark:text-slate-300">RAID-1 FTT=1:</strong> 2-way
+            mirror, requires minimum 3 hosts. 50% storage efficiency. Best read performance.
           </p>
         )}
         {isOsa && topology.level === 'vsan_osa_raid1_ftt2' && (
           <p>
-            <strong className="text-slate-300">RAID-1 FTT=2:</strong> 3-way mirror, requires minimum
-            5 hosts. 33% storage efficiency. Maximum fault tolerance.
+            <strong className="text-slate-600 dark:text-slate-300">RAID-1 FTT=2:</strong> 3-way
+            mirror, requires minimum 5 hosts. 33% storage efficiency. Maximum fault tolerance.
           </p>
         )}
         {isOsa && topology.level === 'vsan_osa_raid5' && (
           <p>
-            <strong className="text-slate-300">RAID-5 (3+1):</strong> Single parity, requires
-            minimum 4 hosts. 75% efficiency. 4x write penalty vs mirror.
+            <strong className="text-slate-600 dark:text-slate-300">RAID-5 (3+1):</strong> Single
+            parity, requires minimum 4 hosts. 75% efficiency. 4x write penalty vs mirror.
           </p>
         )}
         {isOsa && topology.level === 'vsan_osa_raid6' && (
           <p>
-            <strong className="text-slate-300">RAID-6 (4+2):</strong> Dual parity, requires minimum
-            6 hosts. 67% efficiency. 6x write penalty vs mirror.
+            <strong className="text-slate-600 dark:text-slate-300">RAID-6 (4+2):</strong> Dual
+            parity, requires minimum 6 hosts. 67% efficiency. 6x write penalty vs mirror.
           </p>
         )}
         {isEsa && topology.level === 'vsan_esa_raid5' && (
           <>
             <p>
-              <strong className="text-slate-300">Adaptive RAID-5:</strong> Uses 2+1 for 3-5 hosts
-              (67% efficiency) or 4+1 for 6+ hosts (80% efficiency). Near RAID-1 performance with
-              ~2.5x write penalty.
+              <strong className="text-slate-600 dark:text-slate-300">Adaptive RAID-5:</strong> Uses
+              2+1 for 3-5 hosts (67% efficiency) or 4+1 for 6+ hosts (80% efficiency). Near RAID-1
+              performance with ~2.5x write penalty.
             </p>
             <p className="mt-1 text-green-400">Recommended for most ESA deployments.</p>
           </>
         )}
         {isEsa && topology.level === 'vsan_esa_raid6' && (
           <p>
-            <strong className="text-slate-300">RAID-6 (4+2):</strong> FTT=2, requires minimum 6
-            hosts. 67% efficiency. ~3.5x write penalty (much better than OSA RAID-6).
+            <strong className="text-slate-600 dark:text-slate-300">RAID-6 (4+2):</strong> FTT=2,
+            requires minimum 6 hosts. 67% efficiency. ~3.5x write penalty (much better than OSA
+            RAID-6).
           </p>
         )}
         {isEsa && topology.level === 'vsan_esa_raid1' && (
           <p>
-            <strong className="text-slate-300">RAID-1 (Mirror):</strong> Only recommended for 2-node
-            stretched clusters. 50% efficiency. Use RAID-5 for better efficiency in 3+ node
-            clusters.
+            <strong className="text-slate-600 dark:text-slate-300">RAID-1 (Mirror):</strong> Only
+            recommended for 2-node stretched clusters. 50% efficiency. Use RAID-5 for better
+            efficiency in 3+ node clusters.
           </p>
         )}
         <p className="mt-2 text-slate-500">
@@ -118,8 +119,8 @@ export function VsanOptionsPanel({ topology }: VsanOptionsPanelProps) {
       {/* Disk Group Tiering (OSA only) */}
       {isOsa && (
         <>
-          <div className="pt-3 border-t border-surface-700">
-            <h5 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3">
+          <div className="pt-3 border-t border-slate-200 dark:border-surface-700">
+            <h5 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-3">
               {t('vsanOsa.diskGroupConfig')}
             </h5>
           </div>

--- a/src/components/inputs/topology-options/ZfsOptionsPanel.tsx
+++ b/src/components/inputs/topology-options/ZfsOptionsPanel.tsx
@@ -41,8 +41,8 @@ export function ZfsOptionsPanel() {
   const { zfsOptions, setZfsOptions } = useConfigStore()
 
   return (
-    <div className="space-y-4 pt-3 border-t border-surface-700">
-      <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
+    <div className="space-y-4 pt-3 border-t border-slate-200 dark:border-surface-700">
+      <h4 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
         {t('zfs.title')}
       </h4>
 

--- a/src/components/layout/Cockpit.tsx
+++ b/src/components/layout/Cockpit.tsx
@@ -22,7 +22,7 @@ export function Cockpit() {
   }
 
   return (
-    <div className="h-screen flex flex-col bg-surface-900">
+    <div className="h-screen flex flex-col bg-slate-50 dark:bg-surface-900">
       <Header onToggleGuide={toggleGuide} isGuideOpen={isGuideOpen} />
 
       {/* Main content - responsive layout */}
@@ -58,15 +58,15 @@ export function Cockpit() {
       </div>
 
       {/* Mobile bottom navigation - only visible on mobile */}
-      <nav className="lg:hidden fixed bottom-0 left-0 right-0 bg-surface-800 border-t border-surface-700 z-50">
+      <nav className="lg:hidden fixed bottom-0 left-0 right-0 bg-white dark:bg-surface-800 border-t border-slate-200 dark:border-surface-700 z-50">
         <div className="flex">
           <button
             type="button"
             onClick={() => setActiveView('config')}
             className={`flex-1 py-3 min-h-[44px] text-sm font-medium transition-colors ${
               activeView === 'config'
-                ? 'text-accent-400 bg-surface-700'
-                : 'text-surface-300 hover:text-surface-100'
+                ? 'text-accent-400 bg-slate-100 dark:bg-surface-700'
+                : 'text-slate-600 dark:text-surface-300 hover:text-slate-900 dark:hover:text-surface-100'
             }`}
           >
             {t('nav.configuration')}
@@ -76,8 +76,8 @@ export function Cockpit() {
             onClick={() => setActiveView('report')}
             className={`flex-1 py-3 min-h-[44px] text-sm font-medium transition-colors ${
               activeView === 'report'
-                ? 'text-accent-400 bg-surface-700'
-                : 'text-surface-300 hover:text-surface-100'
+                ? 'text-accent-400 bg-slate-100 dark:bg-surface-700'
+                : 'text-slate-600 dark:text-surface-300 hover:text-slate-900 dark:hover:text-surface-100'
             }`}
           >
             {t('nav.report')}
@@ -87,8 +87,8 @@ export function Cockpit() {
             onClick={() => setActiveView('guide')}
             className={`flex-1 py-3 min-h-[44px] text-sm font-medium transition-colors ${
               activeView === 'guide'
-                ? 'text-accent-400 bg-surface-700'
-                : 'text-surface-300 hover:text-surface-100'
+                ? 'text-accent-400 bg-slate-100 dark:bg-surface-700'
+                : 'text-slate-600 dark:text-surface-300 hover:text-slate-900 dark:hover:text-surface-100'
             }`}
           >
             {t('nav.guide')}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -4,6 +4,7 @@
 
 import { useTranslation } from 'react-i18next'
 import { LanguageSwitcher, SegmentedControl, Select } from '@/components/common'
+import { ThemeToggle } from '@/components/common/ThemeToggle'
 import { useConfigStore } from '@/store'
 import type { CarbonRegion } from '@/types'
 
@@ -35,7 +36,7 @@ export function Header({ onToggleGuide, isGuideOpen }: HeaderProps) {
   }))
 
   return (
-    <header className="bg-surface-800 border-b border-surface-700 px-6 py-4">
+    <header className="bg-white border-b border-slate-200 px-6 py-4 dark:bg-surface-800 dark:border-surface-700">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           <img
@@ -44,14 +45,14 @@ export function Header({ onToggleGuide, isGuideOpen }: HeaderProps) {
             className="w-8 h-8 rounded-lg"
           />
           <div>
-            <h1 className="text-xl font-bold text-white">{t('app.title')}</h1>
-            <p className="text-xs text-slate-400">{t('app.subtitle')}</p>
+            <h1 className="text-xl font-bold text-slate-900 dark:text-white">{t('app.title')}</h1>
+            <p className="text-xs text-slate-500 dark:text-slate-400">{t('app.subtitle')}</p>
           </div>
         </div>
 
         <div className="flex items-center gap-4">
           <div className="flex items-center gap-2">
-            <span className="text-xs text-slate-400">{t('carbon.label')}:</span>
+            <span className="text-xs text-slate-500 dark:text-slate-400">{t('carbon.label')}:</span>
             <Select
               id="carbon-region"
               value={carbonRegion}
@@ -60,7 +61,7 @@ export function Header({ onToggleGuide, isGuideOpen }: HeaderProps) {
             />
           </div>
           <div className="flex items-center gap-2">
-            <span className="text-xs text-slate-400">{t('units.label')}:</span>
+            <span className="text-xs text-slate-500 dark:text-slate-400">{t('units.label')}:</span>
             <SegmentedControl
               value={unitSystem}
               options={[
@@ -71,16 +72,19 @@ export function Header({ onToggleGuide, isGuideOpen }: HeaderProps) {
             />
           </div>
           <div className="flex items-center gap-2">
-            <span className="text-xs text-slate-400">{t('language.label')}:</span>
+            <span className="text-xs text-slate-500 dark:text-slate-400">
+              {t('language.label')}:
+            </span>
             <LanguageSwitcher />
           </div>
+          <ThemeToggle />
           <button
             type="button"
             onClick={onToggleGuide}
             className={`hidden lg:flex w-8 h-8 items-center justify-center rounded-lg text-sm font-bold transition-colors ${
               isGuideOpen
                 ? 'bg-primary-600 text-white'
-                : 'bg-surface-700 text-slate-400 hover:text-white hover:bg-surface-600'
+                : 'bg-slate-100 text-slate-500 hover:text-slate-900 hover:bg-slate-200 dark:bg-surface-700 dark:text-slate-400 dark:hover:text-white dark:hover:bg-surface-600'
             }`}
             title={t('nav.guide')}
           >

--- a/src/components/layout/InputSidebar.tsx
+++ b/src/components/layout/InputSidebar.tsx
@@ -30,9 +30,9 @@ export function InputSidebar() {
   }
 
   return (
-    <aside className="w-80 flex-shrink-0 bg-surface-800 border-r border-surface-700 overflow-y-auto">
-      <div className="p-4 border-b border-surface-700">
-        <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider">
+    <aside className="w-80 flex-shrink-0 bg-white dark:bg-surface-800 border-r border-slate-200 dark:border-surface-700 overflow-y-auto">
+      <div className="p-4 border-b border-slate-200 dark:border-surface-700">
+        <h2 className="text-sm font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wider">
           {t('nav.configuration')}
         </h2>
       </div>

--- a/src/components/layout/OutputDashboard.tsx
+++ b/src/components/layout/OutputDashboard.tsx
@@ -39,7 +39,7 @@ function MetricCard({
   label,
   children,
   subvalue,
-  color = 'text-white',
+  color = 'text-slate-900 dark:text-white',
 }: {
   label: string
   children: React.ReactNode
@@ -49,8 +49,8 @@ function MetricCard({
   return (
     <div className="text-center">
       <div className={`text-2xl font-bold ${color}`}>{children}</div>
-      <p className="text-xs text-slate-400">{label}</p>
-      {subvalue && <p className="text-xs text-slate-500 mt-1">{subvalue}</p>}
+      <p className="text-xs text-slate-500 dark:text-slate-400">{label}</p>
+      {subvalue && <p className="text-xs text-slate-500 dark:text-slate-500 mt-1">{subvalue}</p>}
     </div>
   )
 }
@@ -76,12 +76,14 @@ function ProgressBar({
   return (
     <div className="space-y-1">
       <div className="flex justify-between text-sm">
-        <span className="text-slate-400">{label}</span>
+        <span className="text-slate-500 dark:text-slate-400">{label}</span>
         {showValue && (
-          <span className="font-mono text-slate-300">{formatNumber(Math.round(value))}</span>
+          <span className="font-mono text-slate-600 dark:text-slate-300">
+            {formatNumber(Math.round(value))}
+          </span>
         )}
       </div>
-      <div className="h-2 bg-surface-700 rounded-full overflow-hidden">
+      <div className="h-2 bg-slate-100 dark:bg-surface-700 rounded-full overflow-hidden">
         <div
           className={`h-full rounded-full transition-all duration-500 ${color}`}
           style={{ width: `${percent}%` }}
@@ -287,7 +289,7 @@ export function OutputDashboard() {
         {/* Capacity Overview Card */}
         <div className="panel xl:col-span-2">
           <div className="flex items-center justify-between mb-4">
-            <h3 className="text-lg font-semibold text-white flex items-center gap-1.5">
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-white flex items-center gap-1.5">
               {t('capacity.title')} <InfoTooltip content={th('output.sankeyDiagram')} />
             </h3>
             <span className="text-sm font-medium">
@@ -306,7 +308,7 @@ export function OutputDashboard() {
 
               {/* Metrics */}
               <div
-                className={`grid gap-4 pt-4 border-t border-surface-700 ${operationalLimit !== null ? 'grid-cols-4' : 'grid-cols-3'}`}
+                className={`grid gap-4 pt-4 border-t border-slate-200 dark:border-surface-700 ${operationalLimit !== null ? 'grid-cols-4' : 'grid-cols-3'}`}
               >
                 <MetricCard label={t('capacity.raw')}>
                   <AnimatedBytes value={volumetry.rawCapacity} />
@@ -351,7 +353,7 @@ export function OutputDashboard() {
               </div>
 
               {/* Capacity Breakdown List - Mobile */}
-              <div className="pt-4 border-t border-surface-700">
+              <div className="pt-4 border-t border-slate-200 dark:border-surface-700">
                 <CapacityBreakdownList volumetry={volumetry} />
               </div>
             </div>
@@ -362,8 +364,12 @@ export function OutputDashboard() {
         {topology.type === 'zfs' && volumetry.zfsDetails && (
           <div className="panel xl:col-span-2">
             <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold text-white">{t('capacity.zfsBreakdown')}</h3>
-              <span className="text-xs text-slate-500">{t('capacity.dualUnitHint')}</span>
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-white">
+                {t('capacity.zfsBreakdown')}
+              </h3>
+              <span className="text-xs text-slate-500 dark:text-slate-500">
+                {t('capacity.dualUnitHint')}
+              </span>
             </div>
             <ZfsCapacityDetails details={volumetry.zfsDetails} />
           </div>
@@ -371,7 +377,7 @@ export function OutputDashboard() {
 
         {/* Performance Gauges Card */}
         <div className="panel">
-          <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-1.5">
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-4 flex items-center gap-1.5">
             {t('performance.title')} <InfoTooltip content={th('output.bottleneck')} />
           </h3>
 
@@ -421,14 +427,16 @@ export function OutputDashboard() {
             />
           </div>
 
-          <div className="mt-4 pt-4 border-t border-surface-700">
-            <p className="text-sm text-slate-400">{performance.bottleneckDescription}</p>
+          <div className="mt-4 pt-4 border-t border-slate-200 dark:border-surface-700">
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              {performance.bottleneckDescription}
+            </p>
           </div>
         </div>
 
         {/* Power & Sustainability Card */}
         <div className="panel">
-          <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-1.5">
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-4 flex items-center gap-1.5">
             {t('power.title')} <InfoTooltip content={th('output.totalPower')} />
           </h3>
 
@@ -437,13 +445,13 @@ export function OutputDashboard() {
               <span className="font-mono">
                 {formatNumber(Math.round(sustainability.powerBreakdown.total))}
               </span>
-              <span className="text-sm text-slate-400 ml-1">W</span>
+              <span className="text-sm text-slate-500 dark:text-slate-400 ml-1">W</span>
             </MetricCard>
             <MetricCard label={t('power.annualEnergy')}>
               <span className="font-mono">
                 {formatNumber(Math.round(sustainability.annualEnergyKwh))}
               </span>
-              <span className="text-sm text-slate-400 ml-1">kWh</span>
+              <span className="text-sm text-slate-500 dark:text-slate-400 ml-1">kWh</span>
             </MetricCard>
           </div>
 
@@ -468,17 +476,19 @@ export function OutputDashboard() {
             />
           </div>
 
-          <div className="mt-4 pt-4 border-t border-surface-700 flex justify-between items-center">
-            <span className="text-slate-400">{t('power.annualCo2')}</span>
-            <span className="text-lg font-bold text-white">
+          <div className="mt-4 pt-4 border-t border-slate-200 dark:border-surface-700 flex justify-between items-center">
+            <span className="text-slate-500 dark:text-slate-400">{t('power.annualCo2')}</span>
+            <span className="text-lg font-bold text-slate-900 dark:text-white">
               {formatNumber(Math.round(sustainability.annualCO2Kg))} kg
             </span>
           </div>
 
           {sustainability.flashEndurance && (
-            <div className="mt-4 pt-4 border-t border-surface-700">
+            <div className="mt-4 pt-4 border-t border-slate-200 dark:border-surface-700">
               <div className="flex items-center justify-between mb-2">
-                <span className="text-sm font-medium text-slate-300">{t('ssd.title')}</span>
+                <span className="text-sm font-medium text-slate-600 dark:text-slate-300">
+                  {t('ssd.title')}
+                </span>
                 <span
                   className={`text-sm font-medium ${
                     sustainability.flashEndurance.surviveProject ? 'text-green-400' : 'text-red-400'
@@ -512,7 +522,7 @@ export function OutputDashboard() {
 
         {/* Bottleneck Analysis Card */}
         <div className="panel">
-          <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-1.5">
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-4 flex items-center gap-1.5">
             {t('performance.bottleneck.title')} <InfoTooltip content={th('output.bottleneck')} />
           </h3>
 
@@ -522,17 +532,19 @@ export function OutputDashboard() {
                 <div className="flex justify-between text-sm">
                   <span
                     className={
-                      layer.isBottleneck ? 'text-orange-400 font-medium' : 'text-slate-400'
+                      layer.isBottleneck
+                        ? 'text-orange-400 font-medium'
+                        : 'text-slate-500 dark:text-slate-400'
                     }
                   >
                     {layer.name}
                     {layer.isBottleneck && ' ⚠'}
                   </span>
-                  <span className="text-slate-300 font-mono text-xs">
+                  <span className="text-slate-600 dark:text-slate-300 font-mono text-xs">
                     {formatNumber(Math.round(layer.throughputMBs))} MB/s
                   </span>
                 </div>
-                <div className="h-1.5 bg-surface-700 rounded-full overflow-hidden">
+                <div className="h-1.5 bg-slate-100 dark:bg-surface-700 rounded-full overflow-hidden">
                   <div
                     className={`h-full rounded-full transition-all duration-500 ${
                       layer.isBottleneck ? 'bg-orange-500' : 'bg-primary-500'
@@ -548,7 +560,7 @@ export function OutputDashboard() {
         {/* Resilience Simulation Card */}
         <div className="panel">
           <div className="flex items-center justify-between mb-4">
-            <h3 className="text-lg font-semibold text-white flex items-center gap-1.5">
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-white flex items-center gap-1.5">
               {t('resilience.title')} <InfoTooltip content={th('output.survivalRate')} />
             </h3>
             <button
@@ -563,11 +575,11 @@ export function OutputDashboard() {
 
           {resilienceRunning && (
             <div className="mb-4">
-              <div className="flex justify-between text-xs text-slate-400 mb-1">
+              <div className="flex justify-between text-xs text-slate-500 dark:text-slate-400 mb-1">
                 <span>{t('resilience.monteCarloSimulation')}</span>
                 <span>{resilienceProgress.percent.toFixed(0)}%</span>
               </div>
-              <div className="h-2 bg-surface-700 rounded-full overflow-hidden">
+              <div className="h-2 bg-slate-100 dark:bg-surface-700 rounded-full overflow-hidden">
                 <div
                   className="h-full bg-primary-500 rounded-full transition-all duration-200"
                   style={{ width: `${resilienceProgress.percent}%` }}
@@ -579,7 +591,7 @@ export function OutputDashboard() {
           {resilienceResult ? (
             <div className="space-y-4">
               {/* Survival Rate */}
-              <div className="text-center py-4 bg-surface-900 rounded-lg">
+              <div className="text-center py-4 bg-slate-50 dark:bg-surface-900 rounded-lg">
                 <p
                   className={`text-4xl font-bold font-mono ${
                     resilienceResult.riskLevel === 'low'
@@ -593,7 +605,7 @@ export function OutputDashboard() {
                 >
                   {resilienceResult.survivalPercent}
                 </p>
-                <p className="text-xs text-slate-400 mt-1">
+                <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
                   {t('resilience.annualSurvivalRate', { nines: resilienceResult.nines })}
                 </p>
               </div>
@@ -601,25 +613,29 @@ export function OutputDashboard() {
               {/* Risk Metrics */}
               <div className="grid grid-cols-2 gap-3 text-sm">
                 <div>
-                  <p className="text-slate-400">{t('resilience.rebuildTime')}</p>
-                  <p className="text-white font-mono">
+                  <p className="text-slate-500 dark:text-slate-400">
+                    {t('resilience.rebuildTime')}
+                  </p>
+                  <p className="text-slate-900 dark:text-white font-mono">
                     {resilienceResult.avgRebuildTimeHours.toFixed(1)}h
                   </p>
                 </div>
                 <div>
-                  <p className="text-slate-400">{t('resilience.ureRisk')}</p>
-                  <p className="text-white font-mono">
+                  <p className="text-slate-500 dark:text-slate-400">{t('resilience.ureRisk')}</p>
+                  <p className="text-slate-900 dark:text-white font-mono">
                     {(resilienceResult.ureProbability * 100).toFixed(3)}%
                   </p>
                 </div>
                 <div>
-                  <p className="text-slate-400">{t('resilience.dualFailure')}</p>
-                  <p className="text-white font-mono">
+                  <p className="text-slate-500 dark:text-slate-400">
+                    {t('resilience.dualFailure')}
+                  </p>
+                  <p className="text-slate-900 dark:text-white font-mono">
                     {(resilienceResult.dualFailureProbability * 100).toFixed(3)}%
                   </p>
                 </div>
                 <div>
-                  <p className="text-slate-400">{t('resilience.riskLevel')}</p>
+                  <p className="text-slate-500 dark:text-slate-400">{t('resilience.riskLevel')}</p>
                   <p
                     className={`font-medium capitalize ${
                       resilienceResult.riskLevel === 'low'
@@ -638,11 +654,11 @@ export function OutputDashboard() {
 
               {/* Recommendations */}
               {resilienceResult.recommendations.length > 0 && (
-                <div className="pt-3 border-t border-surface-700">
-                  <p className="text-xs font-semibold text-slate-400 uppercase mb-2">
+                <div className="pt-3 border-t border-slate-200 dark:border-surface-700">
+                  <p className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase mb-2">
                     {t('resilience.recommendations')}
                   </p>
-                  <ul className="space-y-1 text-xs text-slate-300">
+                  <ul className="space-y-1 text-xs text-slate-600 dark:text-slate-300">
                     {resilienceResult.recommendations.map((rec) => (
                       <li
                         key={`rec-${rec.slice(0, 30).replace(/\s+/g, '-')}`}
@@ -657,25 +673,29 @@ export function OutputDashboard() {
               )}
             </div>
           ) : (
-            <div className="text-center py-8 text-slate-500">
+            <div className="text-center py-8 text-slate-500 dark:text-slate-500">
               <p>{t('resilience.clickToRun')}</p>
               <p className="text-xs mt-1">
                 {isMobile ? '1,000' : '10,000'} {t('resilience.iterations')}
               </p>
-              <p className="text-xs text-slate-600">{t('resilience.includesCorrelated')}</p>
+              <p className="text-xs text-slate-400 dark:text-slate-600">
+                {t('resilience.includesCorrelated')}
+              </p>
             </div>
           )}
         </div>
 
         {/* Commands Card */}
         <div className="panel xl:col-span-3 lg:col-span-2">
-          <h3 className="text-lg font-semibold text-white mb-4">{t('commands.title')}</h3>
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">
+            {t('commands.title')}
+          </h3>
 
-          <div className="bg-surface-900 rounded-lg p-4 font-mono text-sm overflow-x-auto">
+          <div className="bg-slate-50 dark:bg-surface-900 rounded-lg p-4 font-mono text-sm overflow-x-auto">
             {topology.type === 'zfs' && (
               <div className="space-y-4">
                 <div>
-                  <p className="text-slate-500">
+                  <p className="text-slate-500 dark:text-slate-500">
                     # {t('commands.zfs.createPool', { level: topology.level })}
                   </p>
                   <p className="text-green-400">
@@ -684,7 +704,7 @@ export function OutputDashboard() {
                 </div>
                 {zfsOptions.compression && (
                   <div>
-                    <p className="text-slate-500">
+                    <p className="text-slate-500 dark:text-slate-500">
                       # {t('commands.zfs.enableCompression', { type: zfsOptions.compressionType })}
                     </p>
                     <p className="text-green-400">
@@ -693,7 +713,7 @@ export function OutputDashboard() {
                   </div>
                 )}
                 <div>
-                  <p className="text-slate-500">
+                  <p className="text-slate-500 dark:text-slate-500">
                     # {t('commands.zfs.setRecordsize', { size: zfsOptions.recordsize / 1024 })}
                   </p>
                   <p className="text-green-400">
@@ -702,7 +722,9 @@ export function OutputDashboard() {
                 </div>
                 {zfsOptions.dedup && (
                   <div>
-                    <p className="text-slate-500"># {t('commands.zfs.enableDedup')}</p>
+                    <p className="text-slate-500 dark:text-slate-500">
+                      # {t('commands.zfs.enableDedup')}
+                    </p>
                     <p className="text-yellow-400">zfs set dedup=on tank</p>
                   </div>
                 )}
@@ -712,7 +734,7 @@ export function OutputDashboard() {
             {topology.type === 'standard' && (
               <div className="space-y-4">
                 <div>
-                  <p className="text-slate-500">
+                  <p className="text-slate-500 dark:text-slate-500">
                     # {t('commands.mdadm.createArray', { level: topology.level })}
                   </p>
                   <p className="text-green-400">
@@ -722,7 +744,9 @@ export function OutputDashboard() {
                 </div>
                 {performance.xfsAlignment && (
                   <div>
-                    <p className="text-slate-500"># {t('commands.mdadm.formatXfs')}</p>
+                    <p className="text-slate-500 dark:text-slate-500">
+                      # {t('commands.mdadm.formatXfs')}
+                    </p>
                     <p className="text-green-400">
                       mkfs.xfs -d su={performance.xfsAlignment.suValue},sw=
                       {Math.floor(performance.xfsAlignment.swidth / performance.xfsAlignment.sunit)}{' '}
@@ -736,7 +760,9 @@ export function OutputDashboard() {
             {topology.type === 's2d' && (
               <div className="space-y-4">
                 <div>
-                  <p className="text-slate-500"># {t('commands.s2d.createPool')}</p>
+                  <p className="text-slate-500 dark:text-slate-500">
+                    # {t('commands.s2d.createPool')}
+                  </p>
                   <p className="text-green-400">
                     New-StoragePool -StorageSubSystemFriendlyName "Clustered*" `
                   </p>
@@ -746,7 +772,7 @@ export function OutputDashboard() {
                   </p>
                 </div>
                 <div>
-                  <p className="text-slate-500">
+                  <p className="text-slate-500 dark:text-slate-500">
                     # {t('commands.s2d.createVdisk', { level: topology.level })}
                   </p>
                   <p className="text-green-400">
@@ -759,10 +785,10 @@ export function OutputDashboard() {
 
             {topology.type === 'proprietary' && (
               <div>
-                <p className="text-slate-500">
+                <p className="text-slate-500 dark:text-slate-500">
                   # {t('commands.proprietary.config', { level: topology.level })}
                 </p>
-                <p className="text-slate-400">
+                <p className="text-slate-500 dark:text-slate-400">
                   {t('commands.proprietary.referVendor', { level: topology.level })}
                 </p>
               </div>
@@ -772,14 +798,16 @@ export function OutputDashboard() {
 
         {/* Export Card */}
         <div className="panel xl:col-span-3 lg:col-span-2">
-          <h3 className="text-lg font-semibold text-white mb-4">{t('export.title')}</h3>
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">
+            {t('export.title')}
+          </h3>
 
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
             <button
               type="button"
               onClick={handleExportPdf}
               disabled={!selectedDrive}
-              className="flex flex-col items-center gap-2 p-4 rounded-lg bg-surface-700 hover:bg-surface-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="flex flex-col items-center gap-2 p-4 rounded-lg bg-slate-100 dark:bg-surface-700 hover:bg-slate-200 dark:hover:bg-surface-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               <svg
                 className="w-8 h-8 text-red-400"
@@ -795,15 +823,19 @@ export function OutputDashboard() {
                   d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"
                 />
               </svg>
-              <span className="text-sm font-medium text-white">{t('export.pdf')}</span>
-              <span className="text-xs text-slate-400">{t('export.pdfDesc')}</span>
+              <span className="text-sm font-medium text-slate-900 dark:text-white">
+                {t('export.pdf')}
+              </span>
+              <span className="text-xs text-slate-500 dark:text-slate-400">
+                {t('export.pdfDesc')}
+              </span>
             </button>
 
             <button
               type="button"
               onClick={handleExportPptx}
               disabled={!selectedDrive}
-              className="flex flex-col items-center gap-2 p-4 rounded-lg bg-surface-700 hover:bg-surface-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="flex flex-col items-center gap-2 p-4 rounded-lg bg-slate-100 dark:bg-surface-700 hover:bg-slate-200 dark:hover:bg-surface-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               <svg
                 className="w-8 h-8 text-orange-400"
@@ -819,15 +851,19 @@ export function OutputDashboard() {
                   d="M9 17V7m0 10a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2h2a2 2 0 012 2m0 10a2 2 0 002 2h2a2 2 0 002-2M9 7a2 2 0 012-2h2a2 2 0 012 2m0 10V7m0 10a2 2 0 002 2h2a2 2 0 002-2V7a2 2 0 00-2-2h-2a2 2 0 00-2 2"
                 />
               </svg>
-              <span className="text-sm font-medium text-white">{t('export.pptx')}</span>
-              <span className="text-xs text-slate-400">{t('export.pptxDesc')}</span>
+              <span className="text-sm font-medium text-slate-900 dark:text-white">
+                {t('export.pptx')}
+              </span>
+              <span className="text-xs text-slate-500 dark:text-slate-400">
+                {t('export.pptxDesc')}
+              </span>
             </button>
 
             <button
               type="button"
               onClick={handleExportYaml}
               disabled={!selectedDrive}
-              className="flex flex-col items-center gap-2 p-4 rounded-lg bg-surface-700 hover:bg-surface-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="flex flex-col items-center gap-2 p-4 rounded-lg bg-slate-100 dark:bg-surface-700 hover:bg-slate-200 dark:hover:bg-surface-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               <svg
                 className="w-8 h-8 text-yellow-400"
@@ -843,15 +879,19 @@ export function OutputDashboard() {
                   d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
                 />
               </svg>
-              <span className="text-sm font-medium text-white">{t('export.yaml')}</span>
-              <span className="text-xs text-slate-400">{t('export.yamlDesc')}</span>
+              <span className="text-sm font-medium text-slate-900 dark:text-white">
+                {t('export.yaml')}
+              </span>
+              <span className="text-xs text-slate-500 dark:text-slate-400">
+                {t('export.yamlDesc')}
+              </span>
             </button>
 
             <button
               type="button"
               onClick={handleExportAnsible}
               disabled={!selectedDrive}
-              className="flex flex-col items-center gap-2 p-4 rounded-lg bg-surface-700 hover:bg-surface-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="flex flex-col items-center gap-2 p-4 rounded-lg bg-slate-100 dark:bg-surface-700 hover:bg-slate-200 dark:hover:bg-surface-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               <svg
                 className="w-8 h-8 text-blue-400"
@@ -867,15 +907,19 @@ export function OutputDashboard() {
                   d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01"
                 />
               </svg>
-              <span className="text-sm font-medium text-white">{t('export.ansible')}</span>
-              <span className="text-xs text-slate-400">{t('export.ansibleDesc')}</span>
+              <span className="text-sm font-medium text-slate-900 dark:text-white">
+                {t('export.ansible')}
+              </span>
+              <span className="text-xs text-slate-500 dark:text-slate-400">
+                {t('export.ansibleDesc')}
+              </span>
             </button>
 
             <button
               type="button"
               onClick={handleExportTerraform}
               disabled={!selectedDrive}
-              className="flex flex-col items-center gap-2 p-4 rounded-lg bg-surface-700 hover:bg-surface-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="flex flex-col items-center gap-2 p-4 rounded-lg bg-slate-100 dark:bg-surface-700 hover:bg-slate-200 dark:hover:bg-surface-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               <svg
                 className="w-8 h-8 text-purple-400"
@@ -891,12 +935,18 @@ export function OutputDashboard() {
                   d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
                 />
               </svg>
-              <span className="text-sm font-medium text-white">{t('export.terraform')}</span>
-              <span className="text-xs text-slate-400">{t('export.terraformDesc')}</span>
+              <span className="text-sm font-medium text-slate-900 dark:text-white">
+                {t('export.terraform')}
+              </span>
+              <span className="text-xs text-slate-500 dark:text-slate-400">
+                {t('export.terraformDesc')}
+              </span>
             </button>
           </div>
 
-          <p className="text-xs text-slate-500 mt-4 text-center">{t('export.footer')}</p>
+          <p className="text-xs text-slate-500 dark:text-slate-500 mt-4 text-center">
+            {t('export.footer')}
+          </p>
         </div>
       </div>
     </main>

--- a/src/components/outputs/BackupCard.tsx
+++ b/src/components/outputs/BackupCard.tsx
@@ -18,37 +18,39 @@ export function BackupCard({ backup }: BackupCardProps) {
 
   return (
     <>
-      <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-1.5">
+      <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-4 flex items-center gap-1.5">
         {t('backup.title')}
         <InfoTooltip content={th('output.backupRequirements')} />
       </h3>
 
       {/* Main metric: Total backup storage */}
-      <div className="text-center py-4 bg-surface-900 rounded-lg mb-4">
+      <div className="text-center py-4 bg-slate-50 dark:bg-surface-900 rounded-lg mb-4">
         <div className="text-3xl font-bold text-cyan-400">
           <AnimatedBytes value={backup.totalRaw} />
         </div>
-        <p className="text-xs text-slate-400 mt-1">{t('backup.totalStorage')}</p>
+        <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+          {t('backup.totalStorage')}
+        </p>
       </div>
 
       {/* Breakdown grid */}
       <div className="grid grid-cols-2 gap-4">
         <div className="text-center">
-          <div className="text-xl font-bold text-white">
+          <div className="text-xl font-bold text-slate-900 dark:text-white">
             <AnimatedBytes value={backup.dailyChange} />
           </div>
-          <p className="text-xs text-slate-400">{t('backup.dailyChange')}</p>
+          <p className="text-xs text-slate-500 dark:text-slate-400">{t('backup.dailyChange')}</p>
         </div>
         <div className="text-center">
-          <div className="text-xl font-bold text-white">
+          <div className="text-xl font-bold text-slate-900 dark:text-white">
             <AnimatedBytes value={backup.incrementalRaw} />
           </div>
-          <p className="text-xs text-slate-400">{t('backup.incremental')}</p>
+          <p className="text-xs text-slate-500 dark:text-slate-400">{t('backup.incremental')}</p>
         </div>
       </div>
 
       {/* Parameters summary */}
-      <div className="mt-4 pt-4 border-t border-surface-700 flex justify-between text-sm text-slate-400">
+      <div className="mt-4 pt-4 border-t border-slate-200 dark:border-surface-700 flex justify-between text-sm text-slate-500 dark:text-slate-400">
         <span>{t('backup.retention', { days: backup.retentionDays })}</span>
         <span>{t('backup.changeRate', { rate: backup.changeRatePercent })}</span>
       </div>

--- a/src/components/outputs/CapacityBreakdownList.tsx
+++ b/src/components/outputs/CapacityBreakdownList.tsx
@@ -128,7 +128,7 @@ export function CapacityBreakdownList({ volumetry }: CapacityBreakdownListProps)
             <li key={item.label} className="space-y-1">
               {/* Label row */}
               <div className="flex justify-between items-center text-sm">
-                <span className="text-surface-300 flex items-center gap-2">
+                <span className="text-slate-600 dark:text-surface-300 flex items-center gap-2">
                   {/* Color indicator */}
                   <span
                     className="w-3 h-3 rounded-sm flex-shrink-0"
@@ -137,16 +137,18 @@ export function CapacityBreakdownList({ volumetry }: CapacityBreakdownListProps)
                   />
                   {item.label}
                 </span>
-                <span className="font-mono text-surface-200">
+                <span className="font-mono text-slate-800 dark:text-surface-200">
                   {item.isOverhead ? '−' : ''}
                   {formatBytes(absValue)}
-                  <span className="text-surface-500 ml-1">({displayPercentage}%)</span>
+                  <span className="text-slate-500 dark:text-surface-500 ml-1">
+                    ({displayPercentage}%)
+                  </span>
                 </span>
               </div>
 
               {/* Progress bar */}
               <div
-                className="h-2 bg-surface-700 rounded-full overflow-hidden"
+                className="h-2 bg-slate-100 dark:bg-surface-700 rounded-full overflow-hidden"
                 role="progressbar"
                 aria-valuenow={percentage}
                 aria-valuemin={0}
@@ -168,12 +170,14 @@ export function CapacityBreakdownList({ volumetry }: CapacityBreakdownListProps)
       </ul>
 
       {/* Summary line */}
-      <div className="pt-2 mt-2 border-t border-surface-700">
+      <div className="pt-2 mt-2 border-t border-slate-200 dark:border-surface-700">
         <div className="flex justify-between items-center text-sm font-medium">
-          <span className="text-surface-200">{t('capacity.breakdown.effectiveCapacity')}</span>
+          <span className="text-slate-800 dark:text-surface-200">
+            {t('capacity.breakdown.effectiveCapacity')}
+          </span>
           <span className="font-mono text-green-400">{formatBytes(effectiveCapacity)}</span>
         </div>
-        <div className="text-xs text-surface-500 mt-1">
+        <div className="text-xs text-slate-500 dark:text-surface-500 mt-1">
           {((effectiveCapacity / rawCapacity) * 100).toFixed(1)}% {t('capacity.breakdown.ofRaw')}
         </div>
       </div>

--- a/src/components/outputs/DonutChart.tsx
+++ b/src/components/outputs/DonutChart.tsx
@@ -75,7 +75,7 @@ export function DonutChart({
       <div
         id="donut-chart"
         style={{ width: size, height: size }}
-        className="flex items-center justify-center text-slate-500"
+        className="flex items-center justify-center text-slate-500 dark:text-slate-400"
       >
         No data
       </div>
@@ -94,7 +94,7 @@ export function DonutChart({
           fill="none"
           stroke="currentColor"
           strokeWidth={thickness}
-          className="text-surface-700"
+          className="text-slate-200 dark:text-surface-700"
         />
 
         {/* Segments */}
@@ -118,8 +118,12 @@ export function DonutChart({
       {/* Center text */}
       {(centerLabel || centerValue) && (
         <div className="absolute inset-0 flex flex-col items-center justify-center">
-          {centerValue && <span className="text-2xl font-bold text-white">{centerValue}</span>}
-          {centerLabel && <span className="text-xs text-slate-400">{centerLabel}</span>}
+          {centerValue && (
+            <span className="text-2xl font-bold text-slate-900 dark:text-white">{centerValue}</span>
+          )}
+          {centerLabel && (
+            <span className="text-xs text-slate-500 dark:text-slate-400">{centerLabel}</span>
+          )}
         </div>
       )}
     </div>
@@ -147,8 +151,10 @@ export function DonutLegend({ segments }: { segments: DonutSegment[] }) {
                 className="w-3 h-3 rounded-sm flex-shrink-0"
                 style={{ backgroundColor: segment.color }}
               />
-              <span className="text-slate-400 flex-1">{segment.label}</span>
-              <span className="text-slate-300 font-mono">{percent.toFixed(1)}%</span>
+              <span className="text-slate-500 dark:text-slate-400 flex-1">{segment.label}</span>
+              <span className="text-slate-600 dark:text-slate-300 font-mono">
+                {percent.toFixed(1)}%
+              </span>
             </div>
           )
         })}

--- a/src/components/outputs/SankeyDiagram.tsx
+++ b/src/components/outputs/SankeyDiagram.tsx
@@ -159,7 +159,7 @@ export function SankeyDiagram({ volumetry, width = 600, height = 300 }: SankeyDi
   }, [volumetry, width, height])
 
   if (!sankeyData.nodes.length) {
-    return <div className="text-slate-500">No data to display</div>
+    return <div className="text-slate-500 dark:text-slate-400">No data to display</div>
   }
 
   return (
@@ -221,7 +221,7 @@ export function SankeyDiagram({ volumetry, width = 600, height = 300 }: SankeyDi
                   y={nodeHeight / 2}
                   dy="0.35em"
                   textAnchor={i === 0 ? 'start' : 'end'}
-                  className="text-xs fill-slate-300"
+                  className="text-xs fill-slate-600 dark:fill-slate-300"
                 >
                   {nodes[i]?.name}
                 </text>
@@ -231,7 +231,7 @@ export function SankeyDiagram({ volumetry, width = 600, height = 300 }: SankeyDi
                   y={nodeHeight / 2 + 14}
                   dy="0.35em"
                   textAnchor={i === 0 ? 'start' : 'end'}
-                  className="text-xs fill-slate-500 font-mono"
+                  className="text-xs fill-slate-500 dark:fill-slate-400 font-mono"
                 >
                   {formatBytes(nodes[i]?.value || 0)}
                 </text>

--- a/src/components/outputs/Speedometer.tsx
+++ b/src/components/outputs/Speedometer.tsx
@@ -154,7 +154,7 @@ export function Speedometer({
           stroke="currentColor"
           strokeWidth={strokeWidth}
           strokeLinecap="round"
-          className="text-surface-700"
+          className="text-slate-200 dark:text-surface-700"
         />
 
         {/* Colored gradient segments */}
@@ -208,7 +208,7 @@ export function Speedometer({
             y2={tick.y2}
             stroke="currentColor"
             strokeWidth={tick.major ? 2 : 1}
-            className="text-slate-500"
+            className="text-slate-400 dark:text-slate-500"
           />
         ))}
 
@@ -216,17 +216,25 @@ export function Speedometer({
         <path d={needlePath} fill={color} className="transition-all duration-500" />
 
         {/* Center circle */}
-        <circle cx={center} cy={center} r={8} fill="currentColor" className="text-slate-400" />
+        <circle
+          cx={center}
+          cy={center}
+          r={8}
+          fill="currentColor"
+          className="text-slate-500 dark:text-slate-400"
+        />
       </svg>
 
       {/* Value display */}
       <div className="text-center -mt-2">
-        <p className="text-2xl font-bold text-white font-mono">{formattedValue}</p>
-        <p className="text-xs text-slate-400">{unit}</p>
+        <p className="text-2xl font-bold text-slate-900 dark:text-white font-mono">
+          {formattedValue}
+        </p>
+        <p className="text-xs text-slate-500 dark:text-slate-400">{unit}</p>
       </div>
 
       {/* Label */}
-      <p className="text-sm text-slate-300 mt-1">{label}</p>
+      <p className="text-sm text-slate-600 dark:text-slate-300 mt-1">{label}</p>
     </div>
   )
 }

--- a/src/components/outputs/ZfsCapacityDetails.tsx
+++ b/src/components/outputs/ZfsCapacityDetails.tsx
@@ -20,7 +20,7 @@ function CapacityRow({
   description,
   isSubtraction = false,
   highlight = false,
-  color = 'text-slate-300',
+  color = 'text-slate-600 dark:text-slate-300',
 }: {
   label: string
   bytes: number
@@ -34,22 +34,30 @@ function CapacityRow({
 
   return (
     <div
-      className={`flex flex-col sm:flex-row sm:items-center sm:justify-between py-2 ${highlight ? 'bg-surface-800 -mx-3 px-3 rounded' : ''}`}
+      className={`flex flex-col sm:flex-row sm:items-center sm:justify-between py-2 ${highlight ? 'bg-white dark:bg-surface-800 -mx-3 px-3 rounded' : ''}`}
     >
       <div className="flex-1 min-w-0">
-        <span className={`font-medium ${highlight ? 'text-white' : color}`}>{label}</span>
-        {description && <p className="text-xs text-slate-500 mt-0.5">{description}</p>}
+        <span className={`font-medium ${highlight ? 'text-slate-900 dark:text-white' : color}`}>
+          {label}
+        </span>
+        {description && (
+          <p className="text-xs text-slate-500 dark:text-slate-500 mt-0.5">{description}</p>
+        )}
       </div>
       <div className="font-mono text-sm mt-1 sm:mt-0 sm:text-right flex-shrink-0">
         <span
           className={
-            isSubtraction ? 'text-orange-400' : highlight ? 'text-green-400' : 'text-slate-200'
+            isSubtraction
+              ? 'text-orange-400'
+              : highlight
+                ? 'text-green-400'
+                : 'text-slate-800 dark:text-slate-200'
           }
         >
           {sign}
           {formatted.binary}
         </span>
-        <span className="text-slate-500 ml-2">
+        <span className="text-slate-500 dark:text-slate-500 ml-2">
           ({sign}
           {formatted.decimal})
         </span>
@@ -64,10 +72,10 @@ function CapacityRow({
 function SectionDivider({ label }: { label: string }) {
   return (
     <div className="flex items-center gap-2 my-2">
-      <div className="h-px flex-1 bg-surface-600" />
-      <span className="text-xs text-slate-500 px-2">{label}</span>
+      <div className="h-px flex-1 bg-slate-200 dark:bg-surface-600" />
+      <span className="text-xs text-slate-500 dark:text-slate-500 px-2">{label}</span>
       <svg
-        className="w-4 h-4 text-slate-500"
+        className="w-4 h-4 text-slate-500 dark:text-slate-500"
         fill="none"
         viewBox="0 0 24 24"
         stroke="currentColor"
@@ -80,7 +88,7 @@ function SectionDivider({ label }: { label: string }) {
           d="M19 14l-7 7m0 0l-7-7m7 7V3"
         />
       </svg>
-      <div className="h-px flex-1 bg-surface-600" />
+      <div className="h-px flex-1 bg-slate-200 dark:bg-surface-600" />
     </div>
   )
 }
@@ -198,42 +206,44 @@ export function ZfsCapacityDetails({ details }: ZfsCapacityDetailsProps) {
       )}
 
       {/* ZFS Configuration Summary */}
-      <div className="mt-4 pt-4 border-t border-surface-700">
-        <h4 className="text-sm font-semibold text-white mb-2">ZFS Configuration</h4>
+      <div className="mt-4 pt-4 border-t border-slate-200 dark:border-surface-700">
+        <h4 className="text-sm font-semibold text-slate-900 dark:text-white mb-2">
+          ZFS Configuration
+        </h4>
         <div className="grid grid-cols-2 gap-2 text-sm">
           <div>
-            <span className="text-slate-500">Ashift:</span>
-            <span className="text-slate-200 ml-2">{ashift}</span>
-            <span className="text-slate-500 ml-1">({2 ** ashift} bytes)</span>
+            <span className="text-slate-500 dark:text-slate-500">Ashift:</span>
+            <span className="text-slate-800 dark:text-slate-200 ml-2">{ashift}</span>
+            <span className="text-slate-500 dark:text-slate-500 ml-1">({2 ** ashift} bytes)</span>
           </div>
           <div>
-            <span className="text-slate-500">Recordsize:</span>
-            <span className="text-slate-200 ml-2">{recordSize / 1024}K</span>
+            <span className="text-slate-500 dark:text-slate-500">Recordsize:</span>
+            <span className="text-slate-800 dark:text-slate-200 ml-2">{recordSize / 1024}K</span>
           </div>
           {compressionRatio > 1 && (
             <div>
-              <span className="text-slate-500">Compression:</span>
-              <span className="text-slate-200 ml-2">{compressionRatio}×</span>
+              <span className="text-slate-500 dark:text-slate-500">Compression:</span>
+              <span className="text-slate-800 dark:text-slate-200 ml-2">{compressionRatio}×</span>
             </div>
           )}
           {dedupRatio > 1 && (
             <div>
-              <span className="text-slate-500">Deduplication:</span>
-              <span className="text-slate-200 ml-2">{dedupRatio}×</span>
+              <span className="text-slate-500 dark:text-slate-500">Deduplication:</span>
+              <span className="text-slate-800 dark:text-slate-200 ml-2">{dedupRatio}×</span>
             </div>
           )}
         </div>
       </div>
 
       {/* Efficiency Summary */}
-      <div className="mt-4 p-3 bg-surface-800 rounded-lg">
+      <div className="mt-4 p-3 bg-white dark:bg-surface-800 rounded-lg">
         <div className="flex items-center justify-between">
-          <span className="text-sm text-slate-400">Overall Efficiency</span>
+          <span className="text-sm text-slate-500 dark:text-slate-400">Overall Efficiency</span>
           <span className="text-lg font-bold text-primary-400">
             {((practicalUsableCapacity / totalRawCapacity) * 100).toFixed(1)}%
           </span>
         </div>
-        <p className="text-xs text-slate-500 mt-1">
+        <p className="text-xs text-slate-500 dark:text-slate-500 mt-1">
           Practical usable capacity as percentage of raw
         </p>
       </div>

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useState } from 'react'
+
+export type ThemePreference = 'auto' | 'light' | 'dark'
+export type ResolvedTheme = 'light' | 'dark'
+
+const STORAGE_KEY = 'raidy-theme'
+const MEDIA_QUERY = '(prefers-color-scheme: dark)'
+
+const isPreference = (v: unknown): v is ThemePreference =>
+  v === 'auto' || v === 'light' || v === 'dark'
+
+const readStoredPreference = (): ThemePreference => {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY)
+    if (v === 'light' || v === 'dark') return v
+  } catch {
+    // Safari private mode throws on localStorage access. Fall through.
+  }
+  return 'auto'
+}
+
+const persistPreference = (pref: ThemePreference): void => {
+  try {
+    if (pref === 'auto') localStorage.removeItem(STORAGE_KEY)
+    else localStorage.setItem(STORAGE_KEY, pref)
+  } catch {
+    // Safari private mode: silent failure is fine — the preference still
+    // applies for the lifetime of the tab.
+  }
+}
+
+const applyClass = (resolved: ResolvedTheme): void => {
+  const cls = document.documentElement.classList
+  if (resolved === 'dark') cls.add('dark')
+  else cls.remove('dark')
+}
+
+const osPrefersDark = (): boolean => {
+  if (typeof window === 'undefined') return false
+  return window.matchMedia(MEDIA_QUERY).matches
+}
+
+const computeResolved = (pref: ThemePreference): ResolvedTheme => {
+  if (pref === 'light' || pref === 'dark') return pref
+  return osPrefersDark() ? 'dark' : 'light'
+}
+
+/**
+ * 3-state theme preference (`auto` / `light` / `dark`) backed by
+ * `localStorage['raidy-theme']`. `auto` follows the OS via `matchMedia` with
+ * reactive updates; `light` / `dark` override. Toggles `<html class="dark">`.
+ * The FOUC-prevention script in index.html applies the initial class before
+ * first paint using the same key + logic.
+ */
+export function useTheme(): {
+  preference: ThemePreference
+  resolved: ResolvedTheme
+  setPreference(p: ThemePreference): void
+} {
+  const [preference, setPreferenceState] = useState<ThemePreference>(() => readStoredPreference())
+  const [resolved, setResolved] = useState<ResolvedTheme>(() =>
+    computeResolved(readStoredPreference()),
+  )
+
+  // Apply the class + persist on every preference change.
+  useEffect(() => {
+    const next = computeResolved(preference)
+    setResolved(next)
+    applyClass(next)
+    persistPreference(preference)
+  }, [preference])
+
+  // Subscribe to OS changes — only relevant when preference === 'auto'.
+  useEffect(() => {
+    if (preference !== 'auto') return
+    const mq = window.matchMedia(MEDIA_QUERY)
+    const handler = (e: MediaQueryListEvent) => {
+      const next: ResolvedTheme = e.matches ? 'dark' : 'light'
+      setResolved(next)
+      applyClass(next)
+    }
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [preference])
+
+  const setPreference = useCallback((p: ThemePreference) => {
+    if (!isPreference(p)) return
+    setPreferenceState(p)
+  }, [])
+
+  return { preference, resolved, setPreference }
+}

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -39,6 +39,12 @@
     "de": "Deutsch",
     "it": "Italiano"
   },
+  "theme": {
+    "label": "Design",
+    "auto": "Auto",
+    "light": "Hell",
+    "dark": "Dunkel"
+  },
   "buttons": {
     "export": "Exportieren",
     "reset": "Zuruecksetzen",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -39,6 +39,12 @@
     "de": "Deutsch",
     "it": "Italiano"
   },
+  "theme": {
+    "label": "Theme",
+    "auto": "Auto",
+    "light": "Light",
+    "dark": "Dark"
+  },
   "buttons": {
     "export": "Export",
     "reset": "Reset",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -39,6 +39,12 @@
     "de": "Deutsch",
     "it": "Italiano"
   },
+  "theme": {
+    "label": "Thème",
+    "auto": "Auto",
+    "light": "Clair",
+    "dark": "Sombre"
+  },
   "buttons": {
     "export": "Exporter",
     "reset": "Reinitialiser",

--- a/src/i18n/locales/it/common.json
+++ b/src/i18n/locales/it/common.json
@@ -39,6 +39,12 @@
     "de": "Deutsch",
     "it": "Italiano"
   },
+  "theme": {
+    "label": "Tema",
+    "auto": "Auto",
+    "light": "Chiaro",
+    "dark": "Scuro"
+  },
   "buttons": {
     "export": "Esporta",
     "reset": "Ripristina",

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,9 @@
 @import "tailwindcss";
 
+/* Class-based dark mode: `dark:` utilities activate under <html class="dark">.
+ * The theme is driven by useTheme + the FOUC script in index.html. */
+@custom-variant dark (&:where(.dark, .dark *));
+
 /* Custom Raidy theme configuration */
 @theme {
   /* Storage-themed color palette */
@@ -31,22 +35,34 @@
   --font-mono: "JetBrains Mono", "Fira Code", ui-monospace, monospace;
 }
 
-/* Base styles - Dark mode by default */
+/* Base styles — light default, dark override via the .dark class. */
 @layer base {
   html {
+    color-scheme: light;
+  }
+
+  html.dark {
     color-scheme: dark;
   }
 
   body {
-    @apply bg-surface-900 text-slate-100 antialiased;
+    @apply bg-slate-50 text-slate-900 antialiased;
     font-family: system-ui, -apple-system, sans-serif;
+  }
+
+  .dark body {
+    @apply bg-surface-900 text-slate-100;
   }
 }
 
 /* Component classes */
 @layer components {
   .panel {
-    @apply bg-surface-800 rounded-lg border border-surface-700 p-4;
+    @apply bg-white rounded-lg border border-slate-200 p-4;
+  }
+
+  .dark .panel {
+    @apply bg-surface-800 border-surface-700;
   }
 
   .input-group {
@@ -54,10 +70,18 @@
   }
 
   .label {
-    @apply block text-sm font-medium text-slate-300;
+    @apply block text-sm font-medium text-slate-700;
+  }
+
+  .dark .label {
+    @apply text-slate-300;
   }
 
   .gauge-track {
+    stroke: #e2e8f0;
+  }
+
+  .dark .gauge-track {
     stroke: var(--color-surface-700);
   }
 
@@ -68,7 +92,11 @@
 
   /* Accordion styles */
   .accordion-trigger {
-    @apply flex w-full items-center justify-between py-3 px-4 text-left font-medium text-slate-200 hover:bg-surface-700 rounded-lg transition-colors;
+    @apply flex w-full items-center justify-between py-3 px-4 text-left font-medium text-slate-700 hover:bg-slate-100 rounded-lg transition-colors;
+  }
+
+  .dark .accordion-trigger {
+    @apply text-slate-200 hover:bg-surface-700;
   }
 
   .accordion-content {

--- a/src/utils/captureChart.ts
+++ b/src/utils/captureChart.ts
@@ -4,13 +4,16 @@
  */
 import { toPng } from 'html-to-image'
 
-const PNG_OPTIONS = { backgroundColor: '#1A1B2E', pixelRatio: 2 } as const
+/** Capture background matches the active theme so exports aren't dark-on-light. */
+function captureBackground(): string {
+  return document.documentElement.classList.contains('dark') ? '#1A1B2E' : '#ffffff'
+}
 
 /** Rasterize a DOM element (by id) to a PNG data URL, or null if not mounted. */
 async function captureById(id: string): Promise<string | null> {
   const el = document.getElementById(id)
   if (!el) return null
-  return toPng(el, PNG_OPTIONS)
+  return toPng(el, { backgroundColor: captureBackground(), pixelRatio: 2 })
 }
 
 /**

--- a/src/utils/exportPptx.ts
+++ b/src/utils/exportPptx.ts
@@ -42,6 +42,22 @@ export const BRAND = {
   parity: 'E05C3A', // orange-red
 } as const
 
+type Brand = Record<keyof typeof BRAND, string>
+
+/** Light-theme palette — white paper + ink text. Accent/semantic colors are
+ * shared (they read on both). Selected at export time to match the app theme. */
+const BRAND_LIGHT: Brand = {
+  ...BRAND,
+  bg: 'FFFFFF',
+  panel: 'F1F5F9',
+  border: 'E2E8F0',
+  textWhite: '0F172A', // ink — primary text on light
+  textMuted: '475569', // slate-600
+}
+
+/** Active palette for the slide being built; set by exportToPptx per theme. */
+let brand: Brand = BRAND
+
 /** Convert bytes to decimal terabytes (1 TB = 1e12 bytes). */
 function bytesToTB(bytes: number): number {
   return bytes / 1e12
@@ -61,8 +77,8 @@ function addAccentBar(slide: pptxgen.Slide, prs: pptxgen): void {
     y: 0,
     w: 13.33,
     h: 0.08,
-    fill: { color: BRAND.accent },
-    line: { color: BRAND.accent },
+    fill: { color: brand.accent },
+    line: { color: brand.accent },
   })
 }
 
@@ -104,7 +120,7 @@ function addChartOrFallback(
       w: box.w,
       h: 0.5,
       fontSize: 11,
-      color: BRAND.textMuted,
+      color: brand.textMuted,
       italic: true,
       fontFace: FONT,
       align: 'center',
@@ -125,11 +141,11 @@ function addStatLine(
   const runs: pptxgen.TextProps[] = []
   stats.forEach((stat, i) => {
     if (i > 0) {
-      runs.push({ text: '   ·   ', options: { color: BRAND.border, fontFace: FONT, fontSize } })
+      runs.push({ text: '   ·   ', options: { color: brand.border, fontFace: FONT, fontSize } })
     }
     runs.push({
       text: `${stat.label} `,
-      options: { color: BRAND.textMuted, fontFace: FONT, fontSize },
+      options: { color: brand.textMuted, fontFace: FONT, fontSize },
     })
     runs.push({
       text: stat.value,
@@ -146,7 +162,7 @@ function buildSummarySlide(
   charts: { sankey: string | null; gauges: (string | null)[] },
 ): void {
   const slide = prs.addSlide()
-  slide.background = { fill: BRAND.bg }
+  slide.background = { fill: brand.bg }
   addAccentBar(slide, prs)
 
   const { volumetry: vol, performance: perf, resilience, sustainability: sus } = config.results
@@ -161,7 +177,7 @@ function buildSummarySlide(
     h: 0.5,
     fontSize: 22,
     bold: true,
-    color: BRAND.textWhite,
+    color: brand.textWhite,
     fontFace: FONT,
   })
 
@@ -186,7 +202,7 @@ function buildSummarySlide(
     w: 12.6,
     h: 0.28,
     fontSize: 11,
-    color: BRAND.textMuted,
+    color: brand.textMuted,
     fontFace: FONT,
   })
 
@@ -197,7 +213,7 @@ function buildSummarySlide(
   const chartBottom = chartTop + chartH
 
   // Wider Sankey (reads like the web); smaller gauges packed to the right.
-  addSectionLabel(slide, i18n.t('output:pptx.volumetry'), BRAND.capacity, 0.4, 1.0)
+  addSectionLabel(slide, i18n.t('output:pptx.volumetry'), brand.capacity, 0.4, 1.0)
   addChartOrFallback(
     slide,
     charts.sankey,
@@ -205,7 +221,7 @@ function buildSummarySlide(
     'Capacity chart unavailable',
   )
 
-  addSectionLabel(slide, i18n.t('output:pptx.performance'), BRAND.accent, 8.0, 1.0)
+  addSectionLabel(slide, i18n.t('output:pptx.performance'), brand.accent, 8.0, 1.0)
   const gaugeColX: [number, number] = [8.0, 10.5]
   const gaugeRowY: [number, number] = [chartTop + 0.1, chartTop + chartH / 2 + 0.05]
   const gaugeW = 2.45
@@ -230,19 +246,19 @@ function buildSummarySlide(
       {
         label: 'Raw',
         value: `${bytesToTB(vol.rawCapacity).toFixed(1)} TB`,
-        color: BRAND.textWhite,
+        color: brand.textWhite,
       },
       {
         label: 'Usable',
         value: `${bytesToTB(vol.usableCapacity).toFixed(1)} TB`,
-        color: BRAND.capacity,
+        color: brand.capacity,
       },
       {
         label: 'Effective',
         value: `${bytesToTB(vol.effectiveCapacity).toFixed(1)} TB`,
-        color: BRAND.accent,
+        color: brand.accent,
       },
-      { label: 'Efficiency', value: `${vol.efficiency.toFixed(1)}%`, color: BRAND.overhead },
+      { label: 'Efficiency', value: `${vol.efficiency.toFixed(1)}%`, color: brand.overhead },
     ],
     0.4,
     nl0,
@@ -254,17 +270,17 @@ function buildSummarySlide(
       {
         label: 'Parity',
         value: `${bytesToTB(vol.parityOverhead).toFixed(1)} TB`,
-        color: BRAND.parity,
+        color: brand.parity,
       },
       {
         label: 'Spares',
         value: `${bytesToTB(vol.hotSpareOverhead).toFixed(1)} TB`,
-        color: BRAND.overhead,
+        color: brand.overhead,
       },
       {
         label: 'FS',
         value: `${bytesToTB(vol.filesystemOverhead).toFixed(1)} TB`,
-        color: BRAND.textMuted,
+        color: brand.textMuted,
       },
     ],
     0.4,
@@ -275,8 +291,8 @@ function buildSummarySlide(
   addStatLine(
     slide,
     [
-      { label: 'Max Read', value: `${formatIops(perf.maxReadIOPS)} IOPS`, color: BRAND.accent },
-      { label: '/', value: `${perf.maxReadThroughputMBs.toFixed(0)} MB/s`, color: BRAND.textWhite },
+      { label: 'Max Read', value: `${formatIops(perf.maxReadIOPS)} IOPS`, color: brand.accent },
+      { label: '/', value: `${perf.maxReadThroughputMBs.toFixed(0)} MB/s`, color: brand.textWhite },
     ],
     8.0,
     nl0,
@@ -285,11 +301,11 @@ function buildSummarySlide(
   addStatLine(
     slide,
     [
-      { label: 'Max Write', value: `${formatIops(perf.maxWriteIOPS)} IOPS`, color: BRAND.accent },
+      { label: 'Max Write', value: `${formatIops(perf.maxWriteIOPS)} IOPS`, color: brand.accent },
       {
         label: '/',
         value: `${perf.maxWriteThroughputMBs.toFixed(0)} MB/s`,
-        color: BRAND.textWhite,
+        color: brand.textWhite,
       },
     ],
     8.0,
@@ -300,56 +316,56 @@ function buildSummarySlide(
   // ── Extras spread to fill the page ────────────────────────────────────
   let y = nl1 + 0.5
 
-  addSectionLabel(slide, i18n.t('output:pptx.sustainability'), BRAND.overhead, 0.4, y)
+  addSectionLabel(slide, i18n.t('output:pptx.sustainability'), brand.overhead, 0.4, y)
   const energyStats: StatRun[] = [
-    { label: 'Total', value: `${sus.powerBreakdown.total.toFixed(0)} W`, color: BRAND.accent },
-    { label: 'Drives', value: `${sus.powerBreakdown.drives.toFixed(0)} W`, color: BRAND.textMuted },
+    { label: 'Total', value: `${sus.powerBreakdown.total.toFixed(0)} W`, color: brand.accent },
+    { label: 'Drives', value: `${sus.powerBreakdown.drives.toFixed(0)} W`, color: brand.textMuted },
     {
       label: 'Servers',
       value: `${sus.powerBreakdown.servers.toFixed(0)} W`,
-      color: BRAND.textMuted,
+      color: brand.textMuted,
     },
     {
       label: 'Cooling',
       value: `${sus.powerBreakdown.cooling.toFixed(0)} W`,
-      color: BRAND.textMuted,
+      color: brand.textMuted,
     },
-    { label: 'Energy', value: `${sus.annualEnergyKwh.toFixed(0)} kWh/yr`, color: BRAND.textWhite },
-    { label: 'CO₂', value: `${sus.annualCO2Kg.toFixed(0)} kg/yr`, color: BRAND.textWhite },
+    { label: 'Energy', value: `${sus.annualEnergyKwh.toFixed(0)} kWh/yr`, color: brand.textWhite },
+    { label: 'CO₂', value: `${sus.annualCO2Kg.toFixed(0)} kg/yr`, color: brand.textWhite },
   ]
   if (sus.flashEndurance) {
     energyStats.push({
       label: 'Endurance',
       value: `${sus.flashEndurance.expectedLifeYears.toFixed(1)} yr`,
-      color: BRAND.capacity,
+      color: brand.capacity,
     })
   }
   addStatLine(slide, energyStats, 0.4, y + 0.33, 12.6)
   y += 0.85
 
-  addSectionLabel(slide, i18n.t('output:pptx.bottleneck'), BRAND.parity, 0.4, y)
+  addSectionLabel(slide, i18n.t('output:pptx.bottleneck'), brand.parity, 0.4, y)
   const layerStats: StatRun[] = perf.layers.slice(0, 6).map((layer) => ({
     label: layer.name.replace(/\s*\(.*\)\s*$/, ''),
     value: `${layer.throughputMBs.toFixed(0)} MB/s`,
-    color: layer.isBottleneck ? BRAND.parity : BRAND.textWhite,
+    color: layer.isBottleneck ? brand.parity : brand.textWhite,
   }))
   addStatLine(slide, layerStats, 0.4, y + 0.33, 12.6)
   y += 0.85
 
   // Resilience — only when the simulation has actually been run.
   if (resilience) {
-    addSectionLabel(slide, i18n.t('output:pptx.resilience'), BRAND.capacity, 0.4, y)
+    addSectionLabel(slide, i18n.t('output:pptx.resilience'), brand.capacity, 0.4, y)
     addStatLine(
       slide,
       [
-        { label: 'Survival', value: resilience.survivalPercent, color: BRAND.capacity },
-        { label: 'Durability', value: `${resilience.nines} nines`, color: BRAND.capacity },
+        { label: 'Survival', value: resilience.survivalPercent, color: brand.capacity },
+        { label: 'Durability', value: `${resilience.nines} nines`, color: brand.capacity },
         {
           label: 'Rebuild',
           value: `${resilience.avgRebuildTimeHours.toFixed(1)} h`,
-          color: BRAND.textMuted,
+          color: brand.textMuted,
         },
-        { label: 'Risk', value: resilience.riskLevel.toUpperCase(), color: BRAND.overhead },
+        { label: 'Risk', value: resilience.riskLevel.toUpperCase(), color: brand.overhead },
       ],
       0.4,
       y + 0.33,
@@ -363,6 +379,9 @@ function buildSummarySlide(
  * Runs entirely in the browser — no server request is made.
  */
 export async function exportToPptx(config: ExportConfig): Promise<void> {
+  // Follow the app theme: light deck for light mode, dark deck for dark.
+  brand = document.documentElement.classList.contains('dark') ? BRAND : BRAND_LIGHT
+
   // Capture the charts in parallel before building the slide.
   const [sankey, gauges] = await Promise.all([captureSankeyDiagram(), capturePerfGauges()])
 


### PR DESCRIPTION
Adds an **auto light/dark mode** to the web app and makes the **PPTX export follow the theme**, built on Tailwind's class-based `dark:` variant (mirrors the vatlas pattern).

### Web
- `useTheme` hook: **Auto / Light / Dark**, persisted as `localStorage['raidy-theme']`; Auto follows the OS (`prefers-color-scheme`) and reacts to changes.
- Header `ThemeToggle` (sun / moon / monitor).
- Inline FOUC script in `index.html` applies the theme before first paint (no flash). CSP allows inline.
- `index.css`: `@custom-variant dark` + light-default/dark-override base & shared component classes.
- Full component sweep — every hardcoded-dark class now has a light default + `dark:` override. Verified in-browser (light mode flips the whole UI legibly).
- `theme.{label,auto,light,dark}` i18n keys in all four locales.

### Charts & PPTX
- Charts are theme-aware via the CSS sweep (neutral text/tracks flip; saturated data colors read on both).
- PPTX **follows the app theme**: `BRAND_LIGHT` (white paper, ink text) selected at export; chart captures use a theme-matched background. Light app → light deck; dark → dark deck. (Deliberate divergence from vatlas's fixed deck — ADR-0002.)

Verification: typecheck 0 · lint 0 errors · 881 tests · build green. Light mode confirmed via Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v1.7.0

* **New Features**
  * Added theme toggle with auto, light, and dark mode options
  * Theme preference persists across sessions
  * Auto mode follows OS color scheme preference

* **Improvements**
  * Enhanced dark mode styling throughout the application for improved consistency
  * PowerPoint exports now match the current application theme
  * Prevented visual flash when loading with dark mode enabled

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjacquet/raidy/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->