### PR TITLE
fix(ceph): apply compression to effective capacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.1] - 2026-05-24
+
+### Fixed
+- **Ceph compression now reduces effective capacity.** Enabling compression on a Ceph pool previously had no effect — the toggle, the algorithm selector, and the global compression slider were all dead. Effective capacity now reflects the chosen BlueStore algorithm (ZSTD 1.7×, LZ4 1.4×, Snappy 1.3×), gated by the compression toggle. The Ceph panel shows the resulting ratio, and the redundant global compression/dedup sliders are hidden for Ceph (consistent with Nutanix/PowerStore). Ceph has no native inline dedup, so only compression applies.
+
 ## [1.7.0] - 2026-05-24
 
 ### Added

--- a/src/components/inputs/AdvancedPanel.tsx
+++ b/src/components/inputs/AdvancedPanel.tsx
@@ -84,6 +84,7 @@ export function AdvancedPanel() {
     <div className="space-y-6">
       {/* Data Efficiency Section - Only for topologies that don't have platform-specific controls */}
       {/* Excluded: standard RAID, S2D, PowerVault (no inline compression), and platforms with their own controls in TopologyPanel */}
+      {/* Ceph is excluded too: its compression ratio is driven by the algorithm chosen in the Ceph panel */}
       {topology.type !== 'standard' &&
         topology.type !== 's2d' &&
         topology.type !== 'powervault' &&
@@ -91,7 +92,8 @@ export function AdvancedPanel() {
         topology.type !== 'powerscale' &&
         topology.type !== 'objectscale' &&
         topology.type !== 'powerflex' &&
-        topology.type !== 'nutanix' && (
+        topology.type !== 'nutanix' &&
+        topology.type !== 'ceph' && (
           <div className="space-y-4 pt-4 border-t border-slate-200 dark:border-surface-700">
             <h4 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
               {t('dataEfficiency.title')}

--- a/src/components/inputs/topology-options/CephOptionsPanel.tsx
+++ b/src/components/inputs/topology-options/CephOptionsPanel.tsx
@@ -18,6 +18,7 @@ import {
   Toggle,
 } from '@/components/common/FormControls'
 import { TieringPanel } from '@/components/inputs/TieringPanel'
+import { CEPH_COMPRESSION_RATIOS } from '@/engines/volumetry/postProcessing/capacityEnhancements'
 import { useConfigStore } from '@/store'
 import { DEFAULT_TIERING_CONFIG } from '@/types'
 
@@ -70,6 +71,11 @@ export function CephOptionsPanel() {
               setCephOptions({ compressionAlgorithm: v as 'snappy' | 'lz4' | 'zstd' })
             }
           />
+          <p className="text-xs text-slate-500">
+            {t('ceph.expectedRatio', {
+              ratio: CEPH_COMPRESSION_RATIOS[cephOptions.compressionAlgorithm].toFixed(1),
+            })}
+          </p>
         </div>
       )}
 

--- a/src/engines/volumetry/index.ts
+++ b/src/engines/volumetry/index.ts
@@ -230,6 +230,7 @@ export function calculateVolumetry(input: VolumetryInput): VolumetryResult {
       objectscaleOptions,
       powerstoreOptions,
       powerscaleOptions,
+      cephOptions,
     },
   )
 

--- a/src/engines/volumetry/postProcessing/capacityEnhancements.ts
+++ b/src/engines/volumetry/postProcessing/capacityEnhancements.ts
@@ -129,8 +129,10 @@ export function applyCompressionDedup(
   // Ceph has no native inline dedup, so only compression applies (no global ratio).
   // cephOptions may be absent on malformed input; treat that as no compression.
   if (topology.type === 'ceph') {
+    // `?? 1.0` guards against an out-of-range algorithm deserialized from the URL
+    // hash (untrusted state), which would otherwise make effectiveCapacity NaN.
     const cephCompRatio = cephOptions?.compression
-      ? CEPH_COMPRESSION_RATIOS[cephOptions.compressionAlgorithm]
+      ? (CEPH_COMPRESSION_RATIOS[cephOptions.compressionAlgorithm] ?? 1.0)
       : 1.0
     return usableCapacity * cephCompRatio
   }

--- a/src/engines/volumetry/postProcessing/capacityEnhancements.ts
+++ b/src/engines/volumetry/postProcessing/capacityEnhancements.ts
@@ -8,6 +8,7 @@
 
 import type { ZfsCapacityDetails } from '@/types/results'
 import type {
+  CephOptions,
   NetAppOptions,
   NutanixOptions,
   ObjectScaleOptions,
@@ -17,6 +18,21 @@ import type {
   Topology,
   ZfsOptions,
 } from '@/types/topology'
+
+/**
+ * Ceph BlueStore inline-compression ratios by algorithm.
+ *
+ * Algorithm-driven defaults: ZSTD compresses harder than LZ4, which beats
+ * Snappy (the trade-off is CPU cost). These are representative ratios for
+ * mixed/general data — actual ratios depend on the data being stored.
+ * `none` means compression disabled, hence 1.0 (no reduction).
+ */
+export const CEPH_COMPRESSION_RATIOS: Record<CephOptions['compressionAlgorithm'], number> = {
+  none: 1.0,
+  snappy: 1.3,
+  lz4: 1.4,
+  zstd: 1.7,
+}
 
 /**
  * Apply compression and deduplication based on topology support.
@@ -29,6 +45,7 @@ import type {
  * - ObjectScale: Compression for S3 object storage
  * - PowerStore: Compression and deduplication
  * - PowerScale: Compression and deduplication
+ * - Ceph: BlueStore inline compression, ratio driven by the chosen algorithm
  *
  * @param topology - Storage topology configuration
  * @param usableCapacity - Usable capacity before compression/dedup
@@ -49,6 +66,7 @@ export function applyCompressionDedup(
     objectscaleOptions: ObjectScaleOptions
     powerstoreOptions: PowerStoreOptions
     powerscaleOptions: PowerScaleOptions
+    cephOptions: CephOptions
   },
 ): number {
   const {
@@ -58,6 +76,7 @@ export function applyCompressionDedup(
     objectscaleOptions,
     powerstoreOptions,
     powerscaleOptions,
+    cephOptions,
   } = options
 
   // Standard RAID has no compression/deduplication - effectiveCapacity = usableCapacity
@@ -104,6 +123,16 @@ export function applyCompressionDedup(
     const pscCompRatio = powerscaleOptions.compression ? powerscaleOptions.compressionRatio : 1.0
     const pscDedupRatio = powerscaleOptions.dedup ? powerscaleOptions.dedupRatio : 1.0
     return usableCapacity * pscCompRatio * pscDedupRatio
+  }
+
+  // Ceph BlueStore inline compression — ratio is driven by the chosen algorithm.
+  // Ceph has no native inline dedup, so only compression applies (no global ratio).
+  // cephOptions may be absent on malformed input; treat that as no compression.
+  if (topology.type === 'ceph') {
+    const cephCompRatio = cephOptions?.compression
+      ? CEPH_COMPRESSION_RATIOS[cephOptions.compressionAlgorithm]
+      : 1.0
+    return usableCapacity * cephCompRatio
   }
 
   // No compression/dedup support for this topology

--- a/src/i18n/locales/de/topology.json
+++ b/src/i18n/locales/de/topology.json
@@ -275,6 +275,7 @@
     "snappy": "Snappy",
     "lz4": "LZ4",
     "zstd": "ZSTD",
+    "expectedRatio": "Erwartetes Verhältnis: {{ratio}}:1",
     "enableEncryption": "Verschlüsselung aktivieren",
     "journalOnSsd": "Journal/WAL auf SSD",
     "walDbOffload": "WAL/DB auf separatem NVMe",

--- a/src/i18n/locales/en/topology.json
+++ b/src/i18n/locales/en/topology.json
@@ -450,6 +450,7 @@
     "snappy": "Snappy",
     "lz4": "LZ4",
     "zstd": "ZSTD",
+    "expectedRatio": "Expected ratio: {{ratio}}:1",
     "enableEncryption": "Enable Encryption",
     "journalOnSsd": "Journal/WAL on SSD",
     "walDbOffload": "WAL/DB on Separate NVMe",

--- a/src/i18n/locales/fr/topology.json
+++ b/src/i18n/locales/fr/topology.json
@@ -290,6 +290,7 @@
     "snappy": "Snappy",
     "lz4": "LZ4",
     "zstd": "ZSTD",
+    "expectedRatio": "Taux attendu : {{ratio}}:1",
     "enableEncryption": "Activer le chiffrement",
     "journalOnSsd": "Journal/WAL sur SSD",
     "walDbOffload": "WAL/DB sur NVMe séparé",

--- a/src/i18n/locales/it/topology.json
+++ b/src/i18n/locales/it/topology.json
@@ -272,6 +272,7 @@
     "snappy": "Snappy",
     "lz4": "LZ4",
     "zstd": "ZSTD",
+    "expectedRatio": "Rapporto previsto: {{ratio}}:1",
     "enableEncryption": "Abilita crittografia",
     "journalOnSsd": "Journal/WAL su SSD",
     "walDbOffload": "WAL/DB su NVMe separato",

--- a/tests/engines/volumetry.spec.ts
+++ b/tests/engines/volumetry.spec.ts
@@ -1660,6 +1660,21 @@ describe('Volumetry Engine - Ceph', () => {
       )
     })
 
+    it('falls back to no compression for an out-of-range algorithm (malformed URL state)', () => {
+      const input = createInput(12, { type: 'ceph', level: 'ceph_ec_4_2' })
+      input.cephOptions = {
+        ...DEFAULT_CEPH_OPTIONS,
+        compression: true,
+        // Simulate a stale/tampered value deserialized from the URL hash.
+        compressionAlgorithm: 'bogus' as unknown as 'zstd',
+      }
+
+      const result = calculateVolumetry(input)
+
+      expect(Number.isFinite(result.effectiveCapacity)).toBe(true)
+      expect(result.effectiveCapacity).toBeCloseTo(result.usableCapacity, 6)
+    })
+
     it('ignores the global compression slider for Ceph (algorithm-driven only)', () => {
       const input = createInput(12, { type: 'ceph', level: 'ceph_ec_4_2' })
       input.compressionRatio = 3.0 // global slider must not affect Ceph

--- a/tests/engines/volumetry.spec.ts
+++ b/tests/engines/volumetry.spec.ts
@@ -1617,6 +1617,63 @@ describe('Volumetry Engine - Ceph', () => {
       expect(Math.abs(result.usableCapacity - expectedUsable)).toBeLessThan(tolerance)
     })
   })
+
+  describe('Ceph Compression', () => {
+    // Algorithm-driven compression ratios (BlueStore inline compression).
+    // ZSTD compresses harder than LZ4, which beats Snappy.
+    const cephCompressionRatios = {
+      snappy: 1.3,
+      lz4: 1.4,
+      zstd: 1.7,
+    } as const
+
+    it('applies no compression when the Ceph compression toggle is off', () => {
+      const input = createInput(12, { type: 'ceph', level: 'ceph_ec_4_2' })
+      input.cephOptions = {
+        ...DEFAULT_CEPH_OPTIONS,
+        compression: false,
+        compressionAlgorithm: 'zstd',
+      }
+
+      const result = calculateVolumetry(input)
+
+      expect(result.effectiveCapacity).toBeCloseTo(result.usableCapacity, 6)
+    })
+
+    it.each([
+      'snappy',
+      'lz4',
+      'zstd',
+    ] as const)('applies the %s algorithm ratio when compression is enabled', (algorithm) => {
+      const input = createInput(12, { type: 'ceph', level: 'ceph_ec_4_2' })
+      input.cephOptions = {
+        ...DEFAULT_CEPH_OPTIONS,
+        compression: true,
+        compressionAlgorithm: algorithm,
+      }
+
+      const result = calculateVolumetry(input)
+
+      expect(result.effectiveCapacity).toBeCloseTo(
+        result.usableCapacity * cephCompressionRatios[algorithm],
+        6,
+      )
+    })
+
+    it('ignores the global compression slider for Ceph (algorithm-driven only)', () => {
+      const input = createInput(12, { type: 'ceph', level: 'ceph_ec_4_2' })
+      input.compressionRatio = 3.0 // global slider must not affect Ceph
+      input.cephOptions = {
+        ...DEFAULT_CEPH_OPTIONS,
+        compression: true,
+        compressionAlgorithm: 'lz4',
+      }
+
+      const result = calculateVolumetry(input)
+
+      expect(result.effectiveCapacity).toBeCloseTo(result.usableCapacity * 1.4, 6)
+    })
+  })
 })
 
 describe('Volumetry Engine - Nutanix', () => {


### PR DESCRIPTION
## Summary

Ceph compression had **no effect** on capacity — the panel's compression toggle, the algorithm selector, and the global Advanced-panel compression slider were all dead. Root cause: `applyCompressionDedup()` had a branch for every other compression-capable platform but **none for `ceph`**, and `cephOptions` was never passed into it, so Ceph always fell through to `return usableCapacity` (Effective == Usable).

## Changes

- **Engine** (`capacityEnhancements.ts`): add `CEPH_COMPRESSION_RATIOS` (ZSTD 1.7× / LZ4 1.4× / Snappy 1.3×) and a null-safe `ceph` branch gated by the compression toggle; thread `cephOptions` through from `index.ts`.
- **UI** (`AdvancedPanel.tsx`): exclude Ceph from the global compression/dedup sliders — now redundant since the algorithm drives the ratio (same pattern as Nutanix/PowerStore).
- **UI** (`CephOptionsPanel.tsx`): show an "Expected ratio: X:1" hint under the algorithm picker, sourced from the engine constant so UI and math can't drift.
- **i18n**: `ceph.expectedRatio` in EN/FR/DE/IT.
- **Tests**: new "Ceph Compression" block (toggle-off = no change, each algorithm applies its ratio, global slider ignored).
- **CHANGELOG**: `[1.7.1] Fixed` entry.

Ceph (RADOS) has no native inline dedup, so only compression applies. Nutanix was investigated and is already fully wired — no changes.

## Verification

- 886/886 tests pass · `npm run typecheck` clean · lint clean on changed files · semgrep: 0 findings.
- Manual: Ceph EC 8+3, usable 212 TiB → ~360 TiB effective at ZSTD; toggle off → back to 212 TiB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Ceph compression toggle to properly update effective capacity based on the selected BlueStore compression algorithm (ZSTD 1.7×, LZ4 1.4×, Snappy 1.3×).

* **New Features**
  * Ceph UI now displays the resulting compression ratio when compression is enabled.
  * Redundant global compression and dedup sliders are now hidden for Ceph topology.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjacquet/raidy/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->