### PR TITLE
ci: make npm audit advisory (continue-on-error)

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -39,6 +39,10 @@ jobs:
         run: npm ci
 
       - name: npm audit (all deps, LOW+)
+        # Advisory: npm audit hard-fails on transitive CVEs that have no per-PR
+        # Dependabot fix. OSV-Scanner (below) is already non-blocking — keep this
+        # consistent so dependency PRs aren't red-lit by unrelated tree CVEs.
+        continue-on-error: true
         run: npm audit --audit-level=low
 
       - name: OSV-Scanner (lockfile)


### PR DESCRIPTION
npm audit hard-fails the build on transitive CVEs that have no per-PR Dependabot remediation, red-lighting routine dependency PRs even when the code builds and the existing OSV-Scanner/Snyk steps are already non-blocking. This makes npm audit `continue-on-error: true` (still runs and reports in logs, just doesn't gate). Consistent with the repo's existing advisory-scan pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)