### PR TITLE
chore: rename default branch maincd → main (step 1: dual-trigger)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [maincd]
+    branches: [maincd, main]
   pull_request:
-    branches: [maincd]
+    branches: [maincd, main]
   schedule:
     - cron: '0 6 * * 1'
 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -4,10 +4,10 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: ['maincd']
+    branches: ['maincd', 'main']
     tags: ['v*']
   pull_request:
-    branches: ['maincd']
+    branches: ['maincd', 'main']
   workflow_dispatch:
 
 permissions:
@@ -132,19 +132,19 @@ jobs:
           gh release upload "$tag" sbom.cdx.json --clobber
 
       - name: Setup Pages
-        if: github.ref == 'refs/heads/maincd' && github.event_name != 'pull_request'
+        if: (github.ref == 'refs/heads/maincd' || github.ref == 'refs/heads/main') && github.event_name != 'pull_request'
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
         with:
           enablement: true
 
       - name: Upload artifact
-        if: github.ref == 'refs/heads/maincd' && github.event_name != 'pull_request'
+        if: (github.ref == 'refs/heads/maincd' || github.ref == 'refs/heads/main') && github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: './dist'
 
   deploy:
-    if: github.ref == 'refs/heads/maincd' && github.event_name != 'pull_request'
+    if: (github.ref == 'refs/heads/maincd' || github.ref == 'refs/heads/main') && github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -70,7 +70,7 @@ All calculations and data processing happen in the browser:
 
 - GitHub Actions
 - Workflow: `.github/workflows/static.yml`
-- Triggers: Push to `maincd` branch, manual dispatch
+- Triggers: Push to `main` branch, manual dispatch
 - Steps:
   1. Checkout code
   2. Setup Node.js 20

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,9 +143,9 @@ Four Swiss languages: EN (default), FR, DE, IT. Uses `react-i18next` with 8 name
 
 ## Git & CI
 
-- **Main branch**: `maincd`
+- **Main branch**: `main`
 - **CI** (`.github/workflows/ci.yml`): Runs `npm test`, `npm run typecheck`, `npm run lint` on push/PR
-- **Deployment** (`.github/workflows/static.yml`): Builds and deploys to GitHub Pages on push to `maincd`
+- **Deployment** (`.github/workflows/static.yml`): Builds and deploys to GitHub Pages on push to `main`
 - **Base path**: `/raidy/` (configured in `vite.config.ts` for GitHub Pages)
 
 <!-- rtk-instructions v2 -->

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,6 +1,6 @@
 # Configuration: CI, security gates & deployment
 
-The CI/CD pipeline is a single workflow, `.github/workflows/static.yml`, that runs on push and PR to `maincd`, on `v*` tags, and via manual dispatch. It builds on **Node 24** with all third-party actions **pinned to commit SHAs**. A separate `.github/workflows/codeql.yml` runs CodeQL static analysis.
+The CI/CD pipeline is a single workflow, `.github/workflows/static.yml`, that runs on push and PR to `main`, on `v*` tags, and via manual dispatch. It builds on **Node 24** with all third-party actions **pinned to commit SHAs**. A separate `.github/workflows/codeql.yml` runs CodeQL static analysis.
 
 ## Pipeline (build job, in order)
 
@@ -14,7 +14,7 @@ The CI/CD pipeline is a single workflow, `.github/workflows/static.yml`, that ru
 8. **Build** — `npm run build`.
 9. **Bundle-size gate** — `npm run check:bundle-size`.
 10. **CycloneDX SBOM** — generated for prod deps, uploaded as an artifact, and attached to the GitHub Release on `v*` tags.
-11. **Deploy** — Pages artifact upload + deploy, gated to `maincd` non-PR.
+11. **Deploy** — Pages artifact upload + deploy, gated to `main` non-PR.
 
 ## Security gates in detail
 
@@ -36,7 +36,7 @@ When a change legitimately exceeds a budget, bump the threshold in the script on
 
 ## Deployment
 
-GitHub Pages, base path `/raidy/` (set in `vite.config.ts`), served at `https://fjacquet.github.io/raidy/`. Deploy runs only on `maincd` (non-PR) via the Pages artifact mechanism.
+GitHub Pages, base path `/raidy/` (set in `vite.config.ts`), served at `https://fjacquet.github.io/raidy/`. Deploy runs only on `main` (non-PR) via the Pages artifact mechanism.
 
 ## Local equivalents
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -52,9 +52,9 @@ Path aliases are mirrored in `vite.config.ts` and `vitest.config.ts` `resolve.al
 
 ## Git & commits
 
-- Default branch: **`maincd`**.
+- Default branch: **`main`**.
 - Conventional-commit style with phase/scope: `<type>(<scope>): …`, e.g. `feat(17-02): …`, `fix(pptx): …`, `chore(deps): …`.
-- CI runs the full gate set on push/PR to `maincd` — run `npm run typecheck`, `npm run lint`, and `npm run test:run` locally first.
+- CI runs the full gate set on push/PR to `main` — run `npm run typecheck`, `npm run lint`, and `npm run test:run` locally first.
 
 ## Theming (light/dark)
 


### PR DESCRIPTION
Step 1 of renaming the default branch `maincd` (typo) → `main`.

This PR keeps CI zero-gap: workflow triggers and deploy guards now fire on **both** `maincd` and `main`, and docs/badges are updated to `main`. After this merges I rename the branch via the API, then a small cleanup PR drops the `maincd` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)