### PR TITLE
ci: adopt central web-release.yml@v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
     tags: ['v*']
 permissions:
   contents: write
+  id-token: write       # OIDC for build-provenance attestation
+  attestations: write   # write the provenance attestation
 jobs:
   release:
     uses: fjacquet/ci/.github/workflows/web-release.yml@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,14 @@
+name: Release
+on:
+  push:
+    tags: ['v*']
+permissions:
+  contents: write
+jobs:
+  release:
+    uses: fjacquet/ci/.github/workflows/web-release.yml@v1
+    with:
+      node-version: "24"
+      publish-npm: false
+      publish-docker: false
+      build-dir: "dist"


### PR DESCRIPTION
Adds a central reusable release workflow at `.github/workflows/release.yml`.

- Tag-triggered (`v*`) releases via shared `fjacquet/ci/.github/workflows/web-release.yml@v1`
- Produces dist archives + SBOM
- npm and docker publishing disabled
- `node-version: 24`, `build-dir: dist`

actionlint passes (exit 0). All required scripts present in package.json (typecheck, lint, test:run, build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)