### PR TITLE
fix(s2d): correct resiliency validation, write penalty, reserve; expand guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **vSAN compression & deduplication now affect usable capacity.** The compression and deduplication toggles in the vSAN panel were dead — `vsanOptions` was never forwarded to the data-reduction stage and that stage had no vSAN branch, so toggling them changed nothing (both OSA and ESA). Each toggle now drives effective capacity (`C_eff = C_usable × comp × dedup`), with dedicated ratio sliders in the vSAN panel. Defaults follow ESA: compression on (1.5×), dedup off. The redundant global compression/dedup sliders are hidden for vSAN, consistent with Nutanix/Ceph/PowerStore.
+- **S2D best-practice alerts.** Single parity now warns it is supported but not recommended for clustered S2D (`S2D_SINGLE_PARITY_DISCOURAGED`); 2-node clusters are advised to use nested resiliency (`S2D_2NODE_NESTED_RECOMMENDED`); two-way mirror shows an info recommending three-way mirror for production HA (`S2D_3WAY_RECOMMENDED`).
+- **Expanded in-app platform guide for S2D and vSAN ESA.** The guide sections (`PlatformGuide.tsx` + `guide.json`, all four languages) gained resiliency/efficiency tables, replication behavior, rebuild reserve, nested resiliency, and best-practice guidance.
 
 ### Fixed
 - **vSAN no longer reserves dedicated hot spares.** vSAN (OSA and ESA) rebuilds from distributed slack space, not dedicated spare drives, yet the app defaulted to 1 hot spare and deducted a full drive's capacity from usable. Selecting a vSAN topology now forces 0 spares (enforced in the store and defensively in the volumetry/performance hooks so shared URLs cannot reintroduce one), and the hot-spares slider is replaced by an explanatory note.
 - **vSAN ESA bottleneck chain no longer shows a SAS HBA.** ESA is NVMe-only with drives attached directly to PCIe, but the performance chain always inserted a controller layer and defaulted ESA to a "Generic SAS HBA". The controller layer is now dropped for ESA (the chain becomes Media → PCIe → Network), the IOPS ceiling falls back to the PCIe/network limit, and ESA defaults its controller to the NVMe HBA.
+- **S2D resiliency node minimums are now validated.** A new `validateS2DResiliency` check (`src/utils/validators.ts`) enforces Microsoft's fault-domain minimums per resiliency type: three-way mirror and single parity require ≥ 3 fault domains (nodes), dual parity and mirror-accelerated parity (MAP) require ≥ 4. Each violation raises an error alert (`S2D_3WAY_MIN_NODES`, `S2D_PARITY_MIN_NODES`, `S2D_DUAL_PARITY_MIN_NODES`, `S2D_MAP_MIN_NODES`).
+- **S2D mirror write penalty now scales with the copy count.** The performance engine (`src/engines/performance/strategies/s2d.ts`) previously used a flat mirror penalty; it now charges two-way = 2×, three-way = 3×, and MAP = `mirrorCopies + 0.5`, with `s2dOptions` threaded through `PerformanceInput`/`usePerformanceCalc`.
+- **S2D rebuild reserve now follows Microsoft's rule.** The default `drive_failure` strategy reserves 1 capacity drive per server, capped at 4 drives cluster-wide (`capacity_raw × min(faultDomains, 4)`), instead of an uncapped per-node reserve. The reserve is also clamped to the available post-parity capacity so tiny clusters can no longer under-count usable capacity. The default `reserveStrategy` changed from `node_failure` to `drive_failure`; `node_failure` remains as an opt-in whole-node reserve.
 
 ### Changed
 - **Realistic vSAN network bottleneck model.** The network stage compared raw aggregate media bandwidth against a one-directional port aggregate (`speed × nodes`), so a small NVMe cluster was always flagged network-bound. The vSAN network ceiling now accounts for full-duplex links, on-the-wire compression (ESA compresses before replication), and the fraction of throughput that actually crosses the fabric (writes × replication/EC factor + remote reads). Non-vSAN topologies keep the previous model unchanged.
+- **S2D fault-domain bounds tightened from 1–100 to 2–16** (`src/utils/schemas.ts`), matching the supported Microsoft S2D cluster range.
+
+### Known limitations
+- **vSAN ESA adaptive RAID-5 threshold diverges from VMware docs.** Raidy switches RAID-5 to a 4+1 stripe at ≥ 5 hosts AND ≥ 100 drives, whereas VMware documents the 4+1 threshold as ≥ 6 hosts (host-count only). Intentionally left unchanged here; flagged as a follow-up.
+- **vSAN ESA RAID-6 scheme diverges from VMware docs.** Raidy models a 6+2 RAID-6 stripe at ≥ 8 hosts, whereas VMware documents ESA RAID-6 as a fixed 4+2. Intentionally left unchanged here; flagged as a follow-up.
 
 ## [1.7.1] - 2026-05-24
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -133,11 +133,14 @@ Calculates storage capacity and efficiency.
 - Ceph: Replicated and Erasure Coded pools
 - Nutanix, Synology, and more
 
+> Microsoft S2D enforces a minimum number of fault domains (nodes) per resiliency type (validated in `src/utils/validators.ts`): three-way mirror and single parity require ≥ 3, dual parity and mirror-accelerated parity (MAP) require ≥ 4. Fault domains are bounded to 2–16, the supported S2D cluster range.
+
 **Calculations:**
 
 - Raw capacity = drive capacity × drive count
 - Parity overhead (varies by topology)
 - Hot spare capacity reservation (vSAN OSA/ESA use distributed slack space, so no dedicated spares are reserved)
+- S2D rebuild reserve: the default `drive_failure` strategy reserves 1 capacity drive per server, capped at 4 drives cluster-wide (`capacity_raw × min(faultDomains, 4)`), per Microsoft's rule; an opt-in `node_failure` strategy reserves a whole node instead
 - Filesystem overhead (per filesystem type)
 - ZFS slop factor (1/32 of pool)
 - Platform-specific losses
@@ -159,7 +162,7 @@ flowchart LR
 **Calculations:**
 
 - Per-drive IOPS and bandwidth
-- RAID write penalty (2x for RAID1, 4x for RAID5, 6x for RAID6)
+- RAID write penalty (2x for RAID1, 4x for RAID5, 6x for RAID6); S2D mirror write penalty scales with the copy count (two-way 2×, three-way 3×, MAP = `mirrorCopies + 0.5`), with `s2dOptions` threaded through `PerformanceInput`/`usePerformanceCalc`
 - Controller limits (IOPS and throughput caps) — skipped for NVMe-direct topologies (vSAN ESA)
 - PCIe bandwidth (lanes × generation speed)
 - Network bandwidth limits — for vSAN, refined by full-duplex, on-the-wire compression, and the east-west traffic fraction (writes × replication/EC + remote reads)

--- a/src/components/guide/sections/PlatformGuide.tsx
+++ b/src/components/guide/sections/PlatformGuide.tsx
@@ -34,8 +34,13 @@ export function PlatformGuide() {
 
         <PlatformBlock title={t('platforms.vsanEsa.title')}>
           <div className="space-y-1.5 text-sm text-slate-500 dark:text-slate-400">
+            <p>{t('platforms.vsanEsa.architecture')}</p>
+            <p>{t('platforms.vsanEsa.raid1')}</p>
             <p>{t('platforms.vsanEsa.adaptive')}</p>
-            <p>{t('platforms.vsanEsa.nvme')}</p>
+            <p>{t('platforms.vsanEsa.raid6')}</p>
+            <p>{t('platforms.vsanEsa.performance')}</p>
+            <p>{t('platforms.vsanEsa.compression')}</p>
+            <p>{t('platforms.vsanEsa.reserve')}</p>
           </div>
           <p className="text-xs text-slate-400 dark:text-slate-600 italic">
             {t('platforms.vsanEsa.source')}
@@ -54,8 +59,12 @@ export function PlatformGuide() {
 
         <PlatformBlock title={t('platforms.s2d.title')}>
           <div className="space-y-1.5 text-sm text-slate-500 dark:text-slate-400">
+            <p>{t('platforms.s2d.resiliency')}</p>
+            <p>{t('platforms.s2d.replication')}</p>
             <p>{t('platforms.s2d.reserve')}</p>
+            <p>{t('platforms.s2d.nested')}</p>
             <p>{t('platforms.s2d.map')}</p>
+            <p>{t('platforms.s2d.refs')}</p>
           </div>
           <p className="text-xs text-slate-400 dark:text-slate-600 italic">
             {t('platforms.s2d.source')}

--- a/src/engines/performance/index.ts
+++ b/src/engines/performance/index.ts
@@ -16,6 +16,7 @@ import type {
   NutanixOptions,
   PowerFlexOptions,
   RaidControllerOptions,
+  S2DOptions,
   Topology,
   VsanOptions,
 } from '@/types/topology'
@@ -57,6 +58,7 @@ export interface PerformanceInput {
   cephOptions?: CephOptions
   nutanixOptions?: NutanixOptions
   vsanOptions?: VsanOptions
+  s2dOptions?: S2DOptions
 }
 
 /** Block size in bytes */
@@ -110,10 +112,20 @@ function getStrategy(topologyType: TopologyType): PerformanceStrategy {
  * This is the number of I/O operations required per write.
  * Delegates to topology-specific strategy for calculation.
  */
-function getRaidWritePenalty(topology: Topology, serverCount: number): number {
+function getRaidWritePenalty(
+  topology: Topology,
+  serverCount: number,
+  s2dOptions?: S2DOptions,
+): number {
   const strategy = getStrategy(topology.type)
-  // For standard RAID, pass serverCount as number of RAID groups for RAID 50/60
-  const options = topology.type === 'standard' ? { serverCount } : topology
+  // Each strategy interprets `options` differently: standard RAID needs the RAID-group
+  // count for RAID 50/60, S2D needs its mirrorCopies, others read from the topology.
+  let options: unknown = topology
+  if (topology.type === 'standard') {
+    options = { serverCount }
+  } else if (topology.type === 's2d') {
+    options = s2dOptions
+  }
   return strategy.getWritePenalty(topology.level, options)
 }
 
@@ -138,6 +150,7 @@ export function calculatePerformance(input: PerformanceInput): PerformanceResult
     cephOptions,
     nutanixOptions,
     vsanOptions,
+    s2dOptions,
   } = input
 
   const usableDrives = driveCount - hotSpares
@@ -146,7 +159,7 @@ export function calculatePerformance(input: PerformanceInput): PerformanceResult
   const blockSizeBytes = BLOCK_SIZE_BYTES[blockSize]
 
   // Calculate write penalty for random I/O
-  const randomWritePenalty = getRaidWritePenalty(topology, serverCount)
+  const randomWritePenalty = getRaidWritePenalty(topology, serverCount, s2dOptions)
 
   // Sequential write penalty is reduced (full-stripe writes avoid read-modify-write)
   // For RAID 5/6, sequential penalty ≈ 1 + parity_drives/data_drives

--- a/src/engines/performance/strategies/s2d.ts
+++ b/src/engines/performance/strategies/s2d.ts
@@ -1,23 +1,27 @@
+import type { S2DOptions } from '@/types/topology'
 import type { PerformanceStrategy } from './PerformanceStrategy'
 
 /**
  * Microsoft S2D (Storage Spaces Direct) performance strategy.
  *
- * S2D write penalties based on resiliency mode:
+ * S2D write penalties based on resiliency mode (a mirror write fans out to one
+ * backend write per copy, so the penalty scales with mirrorCopies):
  * - simple: 1x (no redundancy)
- * - mirror: 2x (2-way mirror)
+ * - mirror: 2x (2-way) or 3x (3-way) — equals mirrorCopies
  * - parity: 3x (single parity with journal)
  * - dual_parity: 4x (dual parity with journal)
- * - map: 2.5x (Mirror-Accelerated Parity blend)
+ * - map: mirrorCopies + 0.5 (writes mostly land on the mirror tier; small parity surcharge)
  */
 export const s2dPerformanceStrategy: PerformanceStrategy = {
-  getWritePenalty(level: string): number {
+  getWritePenalty(level: string, options?: unknown): number {
+    const mirrorCopies = (options as S2DOptions | undefined)?.mirrorCopies ?? 2
+
     switch (level) {
       case 'simple':
         return 1.0 // No redundancy
 
       case 'mirror':
-        return 2.0 // 2-way mirror writes
+        return mirrorCopies // One backend write per copy (2-way = 2x, 3-way = 3x)
 
       case 'parity':
         return 3.0 // Single parity with journal optimization
@@ -26,7 +30,7 @@ export const s2dPerformanceStrategy: PerformanceStrategy = {
         return 4.0 // Dual parity with journal
 
       case 'map':
-        return 2.5 // Mirror-Accelerated Parity (blend of mirror and parity)
+        return mirrorCopies + 0.5 // Mirror-Accelerated Parity (mostly mirror-tier writes)
 
       default:
         return 1.0

--- a/src/engines/volumetry/overhead/overheadCalculator.ts
+++ b/src/engines/volumetry/overhead/overheadCalculator.ts
@@ -107,16 +107,22 @@ export function calculateOverheads(input: OverheadInput): OverheadResult {
     synologySystemOverhead = synologyOptions.systemPartitionSize * usableDrives
   }
 
-  // S2D rebuild reserve (per-drive or per-node based on reserveStrategy)
+  // S2D rebuild reserve.
+  // Microsoft sizes drive-failure reserve as one capacity drive per server, capped at 4
+  // drives cluster-wide (see Storage Spaces Direct fault-tolerance guidance). The optional
+  // node_failure strategy is a stricter opt-in that reserves a whole node's capacity.
   let s2dReserve = 0
   if (topology.type === 's2d' && s2dOptions.rebuildReserve) {
     if (s2dOptions.reserveStrategy === 'node_failure') {
-      // Reserve one node's worth of capacity
+      // Reserve one node's worth of capacity (stricter, opt-in)
       s2dReserve = drive.capacity_raw * (usableDrives / s2dOptions.faultDomains)
     } else {
-      // Reserve one drive equivalent per fault domain
-      s2dReserve = drive.capacity_raw * s2dOptions.faultDomains
+      // Reserve one drive per server, capped at 4 drives (Microsoft default)
+      s2dReserve = drive.capacity_raw * Math.min(s2dOptions.faultDomains, 4)
     }
+    // Never reserve more than the available post-parity capacity (tiny clusters
+    // can have fewer usable drives than the reserve target).
+    s2dReserve = Math.min(s2dReserve, capacityAfterParity)
   }
 
   // ZFS-specific overhead (slop space = 1/32)
@@ -190,18 +196,20 @@ export function calculateOverheads(input: OverheadInput): OverheadResult {
     synologyOptions,
     netAppOptions,
   )
-  const capacityForFs =
+  const capacityForFs = Math.max(
+    0,
     capacityAfterParity -
-    slopOverhead -
-    s2dReserve -
-    powerFlexFgOverhead -
-    netAppSnapshotReserve -
-    nutanixSystemOverhead -
-    objectscaleSystemOverhead -
-    objectscaleGeoOverhead -
-    powerstoreSnapshotReserve -
-    powerstoreSystemOverhead -
-    powerscaleSnapshotReserve
+      slopOverhead -
+      s2dReserve -
+      powerFlexFgOverhead -
+      netAppSnapshotReserve -
+      nutanixSystemOverhead -
+      objectscaleSystemOverhead -
+      objectscaleGeoOverhead -
+      powerstoreSnapshotReserve -
+      powerstoreSystemOverhead -
+      powerscaleSnapshotReserve,
+  )
   const filesystemOverhead = capacityForFs * fsOverheadPercent
 
   // Ceph safe capacity factor (nearfull threshold, default 85%)

--- a/src/hooks/usePerformanceCalc.ts
+++ b/src/hooks/usePerformanceCalc.ts
@@ -32,6 +32,7 @@ export function usePerformanceCalc(): PerformanceResult {
     cephOptions,
     nutanixOptions,
     vsanOptions,
+    s2dOptions,
     // Workload
     readPercent,
     randomPercent,
@@ -82,6 +83,7 @@ export function usePerformanceCalc(): PerformanceResult {
         cephOptions,
         nutanixOptions,
         vsanOptions,
+        s2dOptions,
       })
     } catch (error) {
       console.error('[Performance Engine Error]', {
@@ -126,5 +128,6 @@ export function usePerformanceCalc(): PerformanceResult {
     cephOptions,
     nutanixOptions,
     vsanOptions,
+    s2dOptions,
   ])
 }

--- a/src/i18n/locales/de/guide.json
+++ b/src/i18n/locales/de/guide.json
@@ -102,9 +102,14 @@
     },
     "vsanEsa": {
       "title": "VMware vSAN ESA",
-      "adaptive": "Adaptive RAID-5: vSAN ESA passt die Stripe-Breite automatisch an die Clustergrösse an. 3–5 Hosts verwenden 2+1 (67% Effizienz). 6+ Hosts verwenden 4+1 (80% Effizienz). Fällt ein Host in einem 6-Host-Cluster aus, stuft vSAN nach 24 Stunden automatisch von 4+1 auf 2+1 herunter.",
-      "nvme": "Nur NVMe: ESA erfordert ausschliesslich NVMe-Laufwerke. Jedes Laufwerk dient in einer Single-Tier-Architektur gleichzeitig als Cache und Kapazität.",
-      "source": "Quelle: VMware VCF Blog (Adaptive RAID-5 Erasure Coding), Broadcom TechDocs"
+      "architecture": "Single-Tier NVMe: ESA verwendet einen einzigen reinen NVMe-Tier — keine Cache-/Kapazitäts-Laufwerksgruppen. Die Laufwerke sind direkt an PCIe angebunden, sodass kein RAID-Controller im I/O-Pfad liegt (Raidy entfernt die Controller-Schicht aus der ESA-Engpass-Kette).",
+      "raid1": "RAID-1 (Mirror): FTT=1 speichert 2 Kopien für 50% Effizienz und benötigt mindestens 3 Hosts (2n+1 Hosts für FTT=n). Raidy modelliert ESA RAID-1 für 2-Knoten-Cluster; Cluster mit 3 oder mehr Knoten sollten Erasure Coding bevorzugen.",
+      "adaptive": "Adaptives RAID-5: vSAN wählt die Stripe-Breite anhand der Host-Anzahl — 2+1 (67% Effizienz) bei 3–5 Hosts, 4+1 (80% Effizienz) bei 6+ Hosts — und passt sie automatisch an, wenn Hosts hinzugefügt oder entfernt werden.",
+      "raid6": "RAID-6 (4+2): toleriert zwei Ausfälle bei 67% Effizienz, mindestens 6 Hosts.",
+      "performance": "RAID-5/6 mit RAID-1-Geschwindigkeit: Ein log-strukturiertes Design fasst eingehende Schreibvorgänge zu vollständigen Stripes zusammen, sodass Erasure-Coding-Schreibvorgänge die Read-Modify-Write-Strafe der älteren OSA vermeiden (die bei RAID-5/6 rund 4×/6× kostete).",
+      "compression": "Komprimierung erfolgt pro Speicherrichtlinie und wird angewendet, bevor die Daten das Netzwerk durchqueren (bis zu ~4:1 bei komprimierbaren Daten). Clusterweite Deduplizierung ist nicht Teil des Basis-ESA — globale Deduplizierung kommt mit VMware Cloud Foundation 9.",
+      "reserve": "Reservierte Kapazität: Halten Sie etwa 25–30% frei für die Betriebsreserve plus Host-Rebuild-Reserve. Auto-Policy Management kann eine clusteroptimierte Standardrichtlinie festlegen. vSAN rekonstruiert aus diesem verteilten freien Speicher — es gibt keine dedizierten Hot Spares.",
+      "source": "Quelle: VMware/Broadcom TechDocs — vSAN ESA „RAID-5/6 mit der Leistung von RAID-1“, adaptives RAID-5 Erasure Coding, Konzepte der reservierten Kapazität"
     },
     "ceph": {
       "title": "Ceph",
@@ -114,9 +119,13 @@
     },
     "s2d": {
       "title": "Storage Spaces Direct (S2D)",
-      "reserve": "Rebuild-Reserve: S2D reserviert ein Laufwerksäquivalent an Kapazität pro Knoten für den automatischen Rebuild. In einem 4-Knoten-Cluster mit 8 Laufwerken pro Knoten gehen 8 Laufwerke (25% der Gesamtkapazität) als Rebuild-Reserve verloren.",
-      "map": "MAP (Mirror-Accelerated Parity): Kombiniert ~20% Spiegel-Tier für heisse Daten mit ~80% Paritäts-Tier für kalte Daten und bietet ein ausgewogenes Verhältnis zwischen Leistung und Kapazitätseffizienz.",
-      "source": "Quelle: Microsoft Storage Spaces Direct-Dokumentation"
+      "resiliency": "Resilienz & Effizienz: two-way mirror (50%, min. 2 Knoten), three-way mirror (33%, min. 3 Knoten — empfohlen für die Produktion), single parity ((N−1)/N, min. 3 Knoten, unterstützt, aber für geclustertes S2D nicht empfohlen), dual parity ((N−2)/N: 50% bei 4 Knoten, ansteigend auf 87,5% bei 16, min. 4 Knoten) und mirror-accelerated parity (Kombination aus mirror + parity, min. 4 Knoten).",
+      "replication": "Replikation & Fehlerdomänen: Jeder Knoten ist eine Fehlerdomäne. Ein mirror hält eine vollständige Kopie pro Knoten und toleriert gleichzeitige Knoten- und Laufwerksausfälle; dual parity toleriert zwei Ausfälle. Cluster umfassen 2–16 Knoten.",
+      "reserve": "Rebuild-Reserve: Lassen Sie ein Kapazitätslaufwerk pro Server für die In-Place-Reparatur frei, begrenzt auf 4 Laufwerke clusterweit — nicht einen ganzen Knoten. So kann S2D nach einem Laufwerksausfall ohne Hardwaretausch rekonstruieren.",
+      "nested": "2-Knoten-Cluster: Verwenden Sie nested resiliency (nested two-way mirror ≈25% oder nested mirror-accelerated parity ≈35–40%) anstelle eines einfachen two-way mirror, damit der Cluster einen Laufwerksausfall während eines Knotenausfalls übersteht.",
+      "map": "MAP (Mirror-Accelerated Parity): Kombiniert einen ~20% mirror-Tier für heisse Daten mit einem ~80% dual-parity-Tier für kalte Daten und schafft so ein ausgewogenes Verhältnis zwischen Leistung und Kapazitätseffizienz.",
+      "refs": "ReFS/CSV: Die Volumes sind ReFS auf Cluster Shared Volumes. Der Metadaten-Overhead ist gering (~2%) und wird durch dieselbe Resilienz wie die Daten geschützt.",
+      "source": "Quelle: Microsoft Learn — Storage Spaces Direct Fehlertoleranz & nested resiliency"
     },
     "nutanix": {
       "title": "Nutanix",

--- a/src/i18n/locales/de/topology.json
+++ b/src/i18n/locales/de/topology.json
@@ -85,7 +85,7 @@
     "mirrorCopies": "Spiegelkopien",
     "2way": "2-Wege",
     "3way": "3-Wege",
-    "rebuildReserve": "Rebuild-Reserve (1 Laufwerk/Knoten)",
+    "rebuildReserve": "Rebuild-Reserve (1 Laufwerk/Knoten, max. 4)",
     "storageTiers": "Speicherebenen aktiviert"
   },
   "vsanOsa": {

--- a/src/i18n/locales/en/guide.json
+++ b/src/i18n/locales/en/guide.json
@@ -102,9 +102,14 @@
     },
     "vsanEsa": {
       "title": "VMware vSAN ESA",
-      "adaptive": "Adaptive RAID-5: vSAN ESA automatically adjusts stripe width based on cluster size. 3\u20135 hosts use 2+1 (67% efficiency). 6+ hosts use 4+1 (80% efficiency). If a host fails in a 6-host cluster, vSAN automatically downgrades from 4+1 to 2+1 after 24 hours.",
-      "nvme": "NVMe Only: ESA requires all-NVMe drives. Each drive serves both cache and capacity in a single-tier architecture.",
-      "source": "Source: VMware VCF Blog (Adaptive RAID-5 Erasure Coding), Broadcom TechDocs"
+      "architecture": "Single-tier NVMe: ESA uses one all-NVMe tier \u2014 no cache/capacity disk groups. Drives attach directly to PCIe, so there is no RAID controller in the I/O path (Raidy drops the controller layer from the ESA bottleneck chain).",
+      "raid1": "RAID-1 (Mirror): FTT=1 stores 2 copies for 50% efficiency and needs at least 3 hosts (2n+1 hosts for FTT=n). Raidy models ESA RAID-1 for 2-node clusters; 3+ node clusters should prefer erasure coding.",
+      "adaptive": "Adaptive RAID-5: vSAN picks the stripe width by host count \u2014 2+1 (67% efficiency) on 3\u20135 hosts, 4+1 (80% efficiency) on 6+ hosts \u2014 and resizes automatically as hosts are added or removed.",
+      "raid6": "RAID-6 (4+2): tolerates two failures at 67% efficiency, minimum 6 hosts.",
+      "performance": "RAID-5/6 at RAID-1 speed: a log-structured design coalesces incoming writes into full stripes, so erasure-coded writes avoid the read-modify-write penalty of the older OSA (which paid roughly 4\u00d7/6\u00d7 on RAID-5/6).",
+      "compression": "Compression is per storage policy and applied before data crosses the network (up to ~4:1 on compressible data). Cluster-wide deduplication is not part of base ESA \u2014 global dedup arrives with VMware Cloud Foundation 9.",
+      "reserve": "Reserved capacity: keep roughly 25\u201330% free for operations reserve plus host-rebuild reserve. Auto-Policy Management can set a cluster-optimized default policy. vSAN rebuilds from this distributed slack space \u2014 there are no dedicated hot spares.",
+      "source": "Source: VMware/Broadcom TechDocs \u2014 vSAN ESA 'RAID-5/6 with the performance of RAID-1', adaptive RAID-5 erasure coding, reserved-capacity concepts"
     },
     "ceph": {
       "title": "Ceph",
@@ -114,9 +119,13 @@
     },
     "s2d": {
       "title": "Storage Spaces Direct (S2D)",
-      "reserve": "Rebuild Reserve: S2D reserves one drive equivalent of capacity per node for automatic rebuild. In a 4-node cluster with 8 drives per node, this means 8 drives (25% of total) are lost to rebuild reserve.",
-      "map": "MAP (Mirror-Accelerated Parity): Combines ~20% mirror tier for hot data with ~80% parity tier for cold data, balancing performance and capacity efficiency.",
-      "source": "Source: Microsoft Storage Spaces Direct documentation"
+      "resiliency": "Resiliency & efficiency: two-way mirror (50%, min 2 nodes), three-way mirror (33%, min 3 nodes — recommended for production), single parity ((N−1)/N, min 3 nodes, supported but not recommended for clustered S2D), dual parity ((N−2)/N: 50% at 4 nodes rising to 87.5% at 16, min 4 nodes), and mirror-accelerated parity (mirror + parity blend, min 4 nodes).",
+      "replication": "Replication & fault domains: every node is a fault domain. A mirror keeps one full copy per node and tolerates simultaneous node and drive failures; dual parity tolerates two failures. Clusters span 2–16 nodes.",
+      "reserve": "Rebuild Reserve: leave one capacity drive per server free for in-place repair, capped at 4 drives cluster-wide — not a whole node. This lets S2D rebuild after a drive failure without replacing hardware.",
+      "nested": "2-node clusters: use nested resiliency (nested two-way mirror ≈25%, or nested mirror-accelerated parity ≈35–40%) instead of plain two-way mirror, so the cluster survives a drive failure during a node outage.",
+      "map": "MAP (Mirror-Accelerated Parity): combines a ~20% mirror tier for hot data with a ~80% dual-parity tier for cold data, balancing performance and capacity efficiency.",
+      "refs": "ReFS/CSV: volumes are ReFS on Cluster Shared Volumes. Metadata overhead is small (~2%) and is protected by the same resiliency as the data.",
+      "source": "Source: Microsoft Learn — Storage Spaces Direct fault tolerance & nested resiliency"
     },
     "nutanix": {
       "title": "Nutanix",

--- a/src/i18n/locales/en/topology.json
+++ b/src/i18n/locales/en/topology.json
@@ -166,7 +166,7 @@
     "mirrorCopies": "Mirror Copies",
     "2way": "2-way",
     "3way": "3-way",
-    "rebuildReserve": "Rebuild Reserve (1 drive/node)",
+    "rebuildReserve": "Rebuild Reserve (1 drive/node, max 4)",
     "storageTiers": "Storage Tiers Enabled"
   },
   "vsanOsa": {

--- a/src/i18n/locales/fr/guide.json
+++ b/src/i18n/locales/fr/guide.json
@@ -102,9 +102,14 @@
     },
     "vsanEsa": {
       "title": "VMware vSAN ESA",
-      "adaptive": "RAID-5 adaptatif : vSAN ESA ajuste automatiquement la largeur de bande en fonction de la taille du cluster. 3 a 5 hotes utilisent 2+1 (67 % d'efficacite). 6+ hotes utilisent 4+1 (80 % d'efficacite). Si un hote tombe en panne dans un cluster de 6 hotes, vSAN retrogade automatiquement de 4+1 a 2+1 apres 24 heures.",
-      "nvme": "NVMe uniquement : ESA necessite des disques entierement NVMe. Chaque disque sert a la fois de cache et de capacite dans une architecture a un seul niveau.",
-      "source": "Source: VMware VCF Blog (Adaptive RAID-5 Erasure Coding), Broadcom TechDocs"
+      "architecture": "NVMe a un seul niveau : ESA utilise un unique niveau entierement NVMe — pas de groupes de disques cache/capacite. Les disques se connectent directement au PCIe, il n'y a donc aucun controleur RAID sur le chemin d'E/S (Raidy supprime la couche controleur de la chaine de goulots d'etranglement ESA).",
+      "raid1": "RAID-1 (Mirror) : FTT=1 stocke 2 copies pour une efficacite de 50 % et necessite au moins 3 hotes (2n+1 hotes pour FTT=n). Raidy modelise le RAID-1 ESA pour les clusters a 2 noeuds ; les clusters de 3 noeuds ou plus devraient privilegier l'erasure coding.",
+      "adaptive": "RAID-5 adaptatif : vSAN choisit la largeur de bande selon le nombre d'hotes — 2+1 (67 % d'efficacite) sur 3 a 5 hotes, 4+1 (80 % d'efficacite) sur 6 hotes ou plus — et se redimensionne automatiquement a mesure que des hotes sont ajoutes ou retires.",
+      "raid6": "RAID-6 (4+2) : tolere deux pannes avec une efficacite de 67 %, minimum 6 hotes.",
+      "performance": "RAID-5/6 a la vitesse du RAID-1 : une conception log-structuree regroupe les ecritures entrantes en bandes completes, de sorte que les ecritures en erasure coding evitent la penalite de lecture-modification-ecriture de l'ancienne OSA (qui payait environ 4x/6x en RAID-5/6).",
+      "compression": "La compression est definie par strategie de stockage et appliquee avant que les donnees ne traversent le reseau (jusqu'a ~4:1 sur des donnees compressibles). La deduplication a l'echelle du cluster ne fait pas partie de l'ESA de base — la deduplication globale arrive avec VMware Cloud Foundation 9.",
+      "reserve": "Capacite reservee : conservez environ 25 a 30 % d'espace libre pour la reserve d'exploitation et la reserve de reconstruction d'hote. Auto-Policy Management peut definir une strategie par defaut optimisee pour le cluster. vSAN reconstruit a partir de cet espace libre distribue — il n'y a pas de disques de secours dedies.",
+      "source": "Source: VMware/Broadcom TechDocs — vSAN ESA « RAID-5/6 avec les performances du RAID-1 », erasure coding RAID-5 adaptatif, concepts de capacite reservee"
     },
     "ceph": {
       "title": "Ceph",
@@ -114,9 +119,13 @@
     },
     "s2d": {
       "title": "Storage Spaces Direct (S2D)",
-      "reserve": "Reserve de reconstruction : S2D reserve l'equivalent de la capacite d'un disque par noeud pour la reconstruction automatique. Dans un cluster de 4 noeuds avec 8 disques par noeud, cela signifie que 8 disques (25 % du total) sont perdus pour la reserve de reconstruction.",
-      "map": "MAP (Mirror-Accelerated Parity) : combine ~20 % de niveau miroir pour les donnees chaudes avec ~80 % de niveau parite pour les donnees froides, equilibrant performances et efficacite de capacite.",
-      "source": "Source: Microsoft Storage Spaces Direct documentation"
+      "resiliency": "Resilience et efficacite : two-way mirror (50 %, min. 2 noeuds), three-way mirror (33 %, min. 3 noeuds — recommande en production), single parity ((N−1)/N, min. 3 noeuds, pris en charge mais non recommande pour le S2D en cluster), dual parity ((N−2)/N : 50 % a 4 noeuds, jusqu'a 87,5 % a 16, min. 4 noeuds) et mirror-accelerated parity (combinaison mirror + parity, min. 4 noeuds).",
+      "replication": "Replication et domaines de panne : chaque noeud est un domaine de panne. Un mirror conserve une copie complete par noeud et tolere des pannes simultanees de noeud et de disque ; le dual parity tolere deux pannes. Les clusters comptent de 2 a 16 noeuds.",
+      "reserve": "Reserve de reconstruction : laissez un disque de capacite libre par serveur pour la reparation sur place, plafonne a 4 disques a l'echelle du cluster — et non un noeud entier. Cela permet a S2D de se reconstruire apres une panne de disque sans remplacer de materiel.",
+      "nested": "Clusters a 2 noeuds : utilisez la nested resiliency (nested two-way mirror ≈ 25 %, ou nested mirror-accelerated parity ≈ 35 a 40 %) plutot qu'un simple two-way mirror, afin que le cluster survive a une panne de disque pendant l'indisponibilite d'un noeud.",
+      "map": "MAP (Mirror-Accelerated Parity) : combine un niveau mirror d'environ 20 % pour les donnees chaudes avec un niveau dual-parity d'environ 80 % pour les donnees froides, equilibrant performances et efficacite de capacite.",
+      "refs": "ReFS/CSV : les volumes sont en ReFS sur des Cluster Shared Volumes. La surcharge de metadonnees est faible (~2 %) et est protegee par la meme resilience que les donnees.",
+      "source": "Source: Microsoft Learn — tolerance aux pannes et nested resiliency de Storage Spaces Direct"
     },
     "nutanix": {
       "title": "Nutanix",

--- a/src/i18n/locales/fr/topology.json
+++ b/src/i18n/locales/fr/topology.json
@@ -88,7 +88,7 @@
     "mirrorCopies": "Copies miroir",
     "2way": "2 voies",
     "3way": "3 voies",
-    "rebuildReserve": "Réserve reconstruction (1 disque/noeud)",
+    "rebuildReserve": "Réserve reconstruction (1 disque/noeud, max 4)",
     "storageTiers": "Niveaux de stockage activés"
   },
   "vsanOsa": {

--- a/src/i18n/locales/it/guide.json
+++ b/src/i18n/locales/it/guide.json
@@ -102,9 +102,14 @@
     },
     "vsanEsa": {
       "title": "VMware vSAN ESA",
-      "adaptive": "RAID 5 adattivo: vSAN ESA regola automaticamente la larghezza dello stripe in base alla dimensione del cluster. Da 3 a 5 host si utilizza 2+1 (67% di efficienza). Da 6+ host si utilizza 4+1 (80% di efficienza). Se un host si guasta in un cluster a 6 host, vSAN passa automaticamente da 4+1 a 2+1 dopo 24 ore.",
-      "nvme": "Solo NVMe: ESA richiede dischi interamente NVMe. Ogni disco funge sia da cache che da capacità in un'architettura a livello singolo.",
-      "source": "Fonte: VMware VCF Blog (Adaptive RAID-5 Erasure Coding), Broadcom TechDocs"
+      "architecture": "NVMe a livello singolo: ESA utilizza un unico livello interamente NVMe — nessun gruppo di dischi cache/capacità. I dischi si collegano direttamente al PCIe, quindi non è presente alcun controller RAID nel percorso di I/O (Raidy rimuove il livello controller dalla catena dei colli di bottiglia ESA).",
+      "raid1": "RAID-1 (Mirror): FTT=1 memorizza 2 copie con un'efficienza del 50% e richiede almeno 3 host (2n+1 host per FTT=n). Raidy modella il RAID-1 ESA per i cluster a 2 nodi; i cluster con 3 o più nodi dovrebbero preferire l'erasure coding.",
+      "adaptive": "RAID-5 adattivo: vSAN sceglie la larghezza dello stripe in base al numero di host — 2+1 (67% di efficienza) su 3–5 host, 4+1 (80% di efficienza) su 6+ host — e si ridimensiona automaticamente quando gli host vengono aggiunti o rimossi.",
+      "raid6": "RAID-6 (4+2): tollera due guasti con un'efficienza del 67%, minimo 6 host.",
+      "performance": "RAID-5/6 alla velocità del RAID-1: un design log-structured aggrega le scritture in arrivo in stripe completi, così le scritture in erasure coding evitano la penalità di lettura-modifica-scrittura della precedente OSA (che costava circa 4×/6× su RAID-5/6).",
+      "compression": "La compressione è definita per criterio di storage e viene applicata prima che i dati attraversino la rete (fino a ~4:1 su dati comprimibili). La deduplicazione a livello di cluster non fa parte dell'ESA di base — la deduplicazione globale arriva con VMware Cloud Foundation 9.",
+      "reserve": "Capacità riservata: mantenere circa il 25–30% di spazio libero per la riserva operativa più la riserva di ricostruzione host. Auto-Policy Management può impostare un criterio predefinito ottimizzato per il cluster. vSAN ricostruisce da questo spazio libero distribuito — non esistono hot spare dedicati.",
+      "source": "Fonte: VMware/Broadcom TechDocs — vSAN ESA «RAID-5/6 con le prestazioni del RAID-1», erasure coding RAID-5 adattivo, concetti di capacità riservata"
     },
     "ceph": {
       "title": "Ceph",
@@ -114,9 +119,13 @@
     },
     "s2d": {
       "title": "Storage Spaces Direct (S2D)",
-      "reserve": "Riserva di ricostruzione: S2D riserva un equivalente di un disco di capacità per nodo per la ricostruzione automatica. In un cluster a 4 nodi con 8 dischi per nodo, questo significa che 8 dischi (25% del totale) sono destinati alla riserva di ricostruzione.",
-      "map": "MAP (Mirror-Accelerated Parity): combina circa il 20% di livello mirror per i dati caldi con circa l'80% di livello parità per i dati freddi, bilanciando prestazioni ed efficienza della capacità.",
-      "source": "Fonte: documentazione Microsoft Storage Spaces Direct"
+      "resiliency": "Resilienza ed efficienza: two-way mirror (50%, min. 2 nodi), three-way mirror (33%, min. 3 nodi — consigliato in produzione), single parity ((N−1)/N, min. 3 nodi, supportato ma non consigliato per S2D in cluster), dual parity ((N−2)/N: 50% con 4 nodi, fino all'87,5% con 16, min. 4 nodi) e mirror-accelerated parity (combinazione di mirror + parity, min. 4 nodi).",
+      "replication": "Replica e domini di guasto: ogni nodo è un dominio di guasto. Un mirror conserva una copia completa per nodo e tollera guasti simultanei di nodo e disco; il dual parity tollera due guasti. I cluster comprendono da 2 a 16 nodi.",
+      "reserve": "Riserva di ricostruzione: lasciare libero un disco di capacità per server per la riparazione in loco, con un limite di 4 dischi a livello di cluster — non un intero nodo. Questo consente a S2D di ricostruire dopo un guasto disco senza sostituire l'hardware.",
+      "nested": "Cluster a 2 nodi: utilizzare la nested resiliency (nested two-way mirror ≈25% o nested mirror-accelerated parity ≈35–40%) anziché un semplice two-way mirror, in modo che il cluster sopravviva a un guasto disco durante l'indisponibilità di un nodo.",
+      "map": "MAP (Mirror-Accelerated Parity): combina un livello mirror di circa il 20% per i dati caldi con un livello dual-parity di circa l'80% per i dati freddi, bilanciando prestazioni ed efficienza della capacità.",
+      "refs": "ReFS/CSV: i volumi sono ReFS su Cluster Shared Volumes. L'overhead dei metadati è ridotto (~2%) ed è protetto dalla stessa resilienza dei dati.",
+      "source": "Fonte: Microsoft Learn — tolleranza ai guasti di Storage Spaces Direct e nested resiliency"
     },
     "nutanix": {
       "title": "Nutanix",

--- a/src/i18n/locales/it/topology.json
+++ b/src/i18n/locales/it/topology.json
@@ -85,7 +85,7 @@
     "mirrorCopies": "Copie mirror",
     "2way": "2 vie",
     "3way": "3 vie",
-    "rebuildReserve": "Riserva ricostruzione (1 disco/nodo)",
+    "rebuildReserve": "Riserva ricostruzione (1 disco/nodo, max 4)",
     "storageTiers": "Livelli storage abilitati"
   },
   "vsanOsa": {

--- a/src/types/topology.ts
+++ b/src/types/topology.ts
@@ -524,7 +524,8 @@ export const DEFAULT_S2D_OPTIONS: S2DOptions = {
   faultDomains: 4,
   mirrorCopies: 2,
   rebuildReserve: true,
-  reserveStrategy: 'node_failure',
+  // Microsoft sizes rebuild reserve as one capacity drive per server (capped at 4).
+  reserveStrategy: 'drive_failure',
   storageTiers: false,
 }
 

--- a/src/utils/schemas.ts
+++ b/src/utils/schemas.ts
@@ -141,7 +141,8 @@ const ZfsOptionsSchema = z.object({
  * S2D options schema
  */
 const S2DOptionsSchema = z.object({
-  faultDomains: z.number().int().min(1).max(100).finite(),
+  // S2D clusters span 2–16 nodes (fault domains) per Microsoft Learn.
+  faultDomains: z.number().int().min(2).max(16).finite(),
   mirrorCopies: z.union([z.literal(2), z.literal(3)]),
   rebuildReserve: z.boolean(),
   reserveStrategy: z.enum(['drive_failure', 'node_failure']),

--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -129,7 +129,7 @@ export function bytesToBinaryTiB(bytes: number): number {
  */
 export function parseCapacity(str: string): number {
   const match = str.match(/^([\d.]+)\s*(PiB|PB|TiB|TB|GiB|GB|MiB|MB|KiB|KB|B)?$/i)
-  if (!match || !match[1]) return 0
+  if (!match?.[1]) return 0
 
   const value = Number.parseFloat(match[1])
   const unit = (match[2] ?? 'TB').toLowerCase()

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -223,6 +223,94 @@ function validateCacheRatio(s2dOptions: S2DOptions): ValidationAlert | null {
 }
 
 /**
+ * Validate S2D resiliency against the fault-domain (node) count and surface
+ * Microsoft best-practice guidance.
+ *
+ * Minimum nodes per resiliency (Microsoft Learn, Storage Spaces Direct fault tolerance):
+ * - three-way mirror: 3 nodes
+ * - single parity: 3 nodes (supported but not recommended for clustered S2D)
+ * - dual parity: 4 nodes
+ * - mirror-accelerated parity: 4 nodes
+ */
+function validateS2DResiliency(topology: Topology, s2dOptions: S2DOptions): ValidationAlert[] {
+  if (topology.type !== 's2d') return []
+
+  const alerts: ValidationAlert[] = []
+  const { faultDomains, mirrorCopies } = s2dOptions
+  const level = topology.level
+
+  // Node minimums per resiliency type (errors).
+  if (level === 'mirror' && mirrorCopies === 3 && faultDomains < 3) {
+    alerts.push({
+      severity: 'error',
+      code: 'S2D_3WAY_MIN_NODES',
+      message: `S2D: Three-way mirror requires at least 3 fault domains (nodes); ${faultDomains} configured.`,
+      recommendation: 'Add nodes or switch to a two-way mirror.',
+    })
+  }
+  if (level === 'parity' && faultDomains < 3) {
+    alerts.push({
+      severity: 'error',
+      code: 'S2D_PARITY_MIN_NODES',
+      message: `S2D: Single parity requires at least 3 fault domains (nodes); ${faultDomains} configured.`,
+      recommendation: 'Add nodes or switch to a mirror resiliency.',
+    })
+  }
+  if (level === 'dual_parity' && faultDomains < 4) {
+    alerts.push({
+      severity: 'error',
+      code: 'S2D_DUAL_PARITY_MIN_NODES',
+      message: `S2D: Dual parity requires at least 4 fault domains (nodes); ${faultDomains} configured.`,
+      recommendation: 'Add nodes or switch to a mirror resiliency.',
+    })
+  }
+  if (level === 'map' && faultDomains < 4) {
+    alerts.push({
+      severity: 'error',
+      code: 'S2D_MAP_MIN_NODES',
+      message: `S2D: Mirror-accelerated parity requires at least 4 fault domains (nodes); ${faultDomains} configured.`,
+      recommendation: 'Add nodes or switch to a mirror resiliency.',
+    })
+  }
+
+  // Single parity is supported but discouraged for clustered S2D (tolerates only one failure).
+  if (level === 'parity') {
+    alerts.push({
+      severity: 'warning',
+      code: 'S2D_SINGLE_PARITY_DISCOURAGED',
+      message:
+        'S2D: Single parity is supported but not recommended for clustered Storage Spaces Direct — it tolerates only one failure.',
+      recommendation: 'Prefer three-way mirror or dual parity.',
+    })
+  }
+
+  // 2-node clusters should use nested resiliency to survive a drive failure during a node outage.
+  if (faultDomains === 2 && level !== 'simple') {
+    alerts.push({
+      severity: 'warning',
+      code: 'S2D_2NODE_NESTED_RECOMMENDED',
+      message:
+        'S2D: 2-node clusters should use nested resiliency to survive a drive failure during a node outage.',
+      recommendation:
+        'Use nested two-way mirror or nested mirror-accelerated parity for 2-node clusters.',
+    })
+  }
+
+  // Three-way mirror is Microsoft's recommended default for production HA.
+  if (level === 'mirror' && mirrorCopies === 2 && faultDomains >= 3) {
+    alerts.push({
+      severity: 'info',
+      code: 'S2D_3WAY_RECOMMENDED',
+      message:
+        "S2D: Two-way mirror tolerates a single failure. Three-way mirror is Microsoft's recommended default for production high availability.",
+      recommendation: 'Switch Mirror Copies to 3-way for two-failure tolerance.',
+    })
+  }
+
+  return alerts
+}
+
+/**
  * Validate NetApp RAID-TEC for large drives.
  * Per NetApp spec: RAID-TEC recommended for drives > 10TB
  */
@@ -480,6 +568,8 @@ export function validateConfiguration(input: ValidationInput): ValidationAlert[]
 
     const cacheRatioAlert = validateCacheRatio(input.s2dOptions)
     if (cacheRatioAlert) alerts.push(cacheRatioAlert)
+
+    alerts.push(...validateS2DResiliency(input.topology, input.s2dOptions))
   }
 
   // Ceph-specific

--- a/tests/engines/performance.spec.ts
+++ b/tests/engines/performance.spec.ts
@@ -370,7 +370,9 @@ describe('Performance Engine - RAID Write Penalty Validation (TEST-12)', () => {
       const resultRaid5 = calculatePerformance(inputRaid5)
       const resultRaid6 = calculatePerformance(inputRaid6)
 
-      expect(resultRaid6.writePenalty).toBeGreaterThan(resultRaid5.writePenalty!)
+      const raid5Penalty = resultRaid5.writePenalty
+      expect(raid5Penalty).toBeDefined()
+      expect(resultRaid6.writePenalty).toBeGreaterThan(raid5Penalty as number)
       expect(resultRaid6.maxWriteIOPS).toBeLessThan(resultRaid5.maxWriteIOPS)
     })
 
@@ -944,7 +946,9 @@ describe('Performance Engine - Industry-Validated IOPS', () => {
       const resultSequential = calculatePerformance(inputSequential)
 
       // Sequential has reduced penalty (full-stripe writes)
-      expect(resultSequential.writePenalty).toBeLessThan(resultRandom.writePenalty!)
+      const randomPenalty = resultRandom.writePenalty
+      expect(randomPenalty).toBeDefined()
+      expect(resultSequential.writePenalty).toBeLessThan(randomPenalty as number)
     })
 
     it('should have higher write throughput for sequential vs random (if not bottlenecked)', () => {
@@ -1304,7 +1308,9 @@ describe('Performance Engine - Dell PowerFlex Performance', () => {
     const result100GbE = calculatePerformance(input100GbE)
 
     // Faster network should reduce latency
-    expect(result100GbE.estimatedLatencyUs).toBeLessThan(result1GbE.estimatedLatencyUs!)
+    const latency1GbE = result1GbE.estimatedLatencyUs
+    expect(latency1GbE).toBeDefined()
+    expect(result100GbE.estimatedLatencyUs).toBeLessThan(latency1GbE as number)
   })
 
   it('should apply PowerFlex erasure coding CPU factor (-30% IOPS)', () => {
@@ -1615,7 +1621,9 @@ describe('Performance Engine - Dell ObjectScale Performance', () => {
     // 1GbE: 500μs * 1.5 = 750μs
     // 100GbE: 10μs * 1.5 = 15μs
     // Difference: 735μs
-    expect(result1GbE.estimatedLatencyUs).toBeGreaterThan(result100GbE.estimatedLatencyUs!)
+    const latency100GbE_obj = result100GbE.estimatedLatencyUs
+    expect(latency100GbE_obj).toBeDefined()
+    expect(result1GbE.estimatedLatencyUs).toBeGreaterThan(latency100GbE_obj as number)
   })
 
   it('should show ObjectScale eventual consistency performance characteristics', () => {
@@ -1652,9 +1660,9 @@ describe('Performance Engine - Dell ObjectScale Performance', () => {
     const resultPowerFlex = calculatePerformance(inputPowerFlex)
 
     // ObjectScale (2x media, 1.5x network) should have higher latency than PowerFlex (1.5x media)
-    expect(resultObjectScale.estimatedLatencyUs).toBeGreaterThan(
-      resultPowerFlex.estimatedLatencyUs!,
-    )
+    const latencyPowerFlexObj = resultPowerFlex.estimatedLatencyUs
+    expect(latencyPowerFlexObj).toBeDefined()
+    expect(resultObjectScale.estimatedLatencyUs).toBeGreaterThan(latencyPowerFlexObj as number)
   })
 })
 
@@ -1708,7 +1716,9 @@ describe('Performance Engine - Dell PowerStore Performance', () => {
     const resultPowerFlex = calculatePerformance(inputPowerFlex)
 
     // PowerStore (1.2x media, no network) should be faster than PowerFlex (1.5x media + network)
-    expect(resultPowerStore.estimatedLatencyUs).toBeLessThan(resultPowerFlex.estimatedLatencyUs!)
+    const latencyPowerFlexPs = resultPowerFlex.estimatedLatencyUs
+    expect(latencyPowerFlexPs).toBeDefined()
+    expect(resultPowerStore.estimatedLatencyUs).toBeLessThan(latencyPowerFlexPs as number)
   })
 
   it('should handle PowerStore block storage performance characteristics', () => {
@@ -1750,7 +1760,9 @@ describe('Performance Engine - Dell PowerStore Performance', () => {
     // NVMe should have lower latency
     // NVMe: 20μs * 1.2 + 10 = 34μs
     // SSD: 150μs * 1.2 + 10 = 190μs
-    expect(resultNvme.estimatedLatencyUs).toBeLessThan(resultSsd.estimatedLatencyUs!)
+    const latencySsd = resultSsd.estimatedLatencyUs
+    expect(latencySsd).toBeDefined()
+    expect(resultNvme.estimatedLatencyUs).toBeLessThan(latencySsd as number)
   })
 
   it('should not include network latency component (block storage)', () => {
@@ -1861,7 +1873,9 @@ describe('Performance Engine - Dell PowerScale Performance', () => {
     // 1GbE: 500μs
     // 100GbE: 10μs
     // Difference: 490μs
-    expect(result1GbE.estimatedLatencyUs).toBeGreaterThan(result100GbE.estimatedLatencyUs!)
+    const latency100GbEPs = result100GbE.estimatedLatencyUs
+    expect(latency100GbEPs).toBeDefined()
+    expect(result1GbE.estimatedLatencyUs).toBeGreaterThan(latency100GbEPs as number)
   })
 
   it('should validate PowerScale parity write performance (1.5x multiplier)', () => {
@@ -1895,9 +1909,9 @@ describe('Performance Engine - Dell PowerScale Performance', () => {
     // PowerScale (1.5x + network) should have higher latency than PowerStore (1.2x, no network)
     // PowerScale: 150 * 1.5 + 25 + 20 = 270μs
     // PowerStore: 150 * 1.2 + 10 = 190μs
-    expect(resultPowerScale.estimatedLatencyUs).toBeGreaterThan(
-      resultPowerStore.estimatedLatencyUs!,
-    )
+    const latencyPowerStorePs = resultPowerStore.estimatedLatencyUs
+    expect(latencyPowerStorePs).toBeDefined()
+    expect(resultPowerScale.estimatedLatencyUs).toBeGreaterThan(latencyPowerStorePs as number)
   })
 })
 
@@ -2057,15 +2071,21 @@ describe('Performance Engine - Nutanix DSF Performance', () => {
       const result10GbE = calculatePerformance(input10GbE)
 
       // RDMA should be fastest
-      expect(resultRdma.estimatedLatencyUs).toBeLessThan(result25GbE.estimatedLatencyUs!)
-      expect(result25GbE.estimatedLatencyUs).toBeLessThan(result10GbE.estimatedLatencyUs!)
+      const latencyRdma = resultRdma.estimatedLatencyUs
+      const latency25GbE = result25GbE.estimatedLatencyUs
+      const latency10GbE = result10GbE.estimatedLatencyUs
+      expect(latencyRdma).toBeDefined()
+      expect(latency25GbE).toBeDefined()
+      expect(latency10GbE).toBeDefined()
+      expect(latencyRdma).toBeLessThan(latency25GbE as number)
+      expect(latency25GbE).toBeLessThan(latency10GbE as number)
 
       // Network latency differences:
       // RDMA: 100μs
       // 25GbE: 250μs (150μs more)
       // 10GbE: 500μs (250μs more)
-      expect(result25GbE.estimatedLatencyUs! - resultRdma.estimatedLatencyUs!).toBeCloseTo(150, -1)
-      expect(result10GbE.estimatedLatencyUs! - result25GbE.estimatedLatencyUs!).toBeCloseTo(250, -1)
+      expect((latency25GbE as number) - (latencyRdma as number)).toBeCloseTo(150, -1)
+      expect((latency10GbE as number) - (latency25GbE as number)).toBeCloseTo(250, -1)
     })
   })
 
@@ -2095,12 +2115,15 @@ describe('Performance Engine - Nutanix DSF Performance', () => {
       const resultWithCompression = calculatePerformance(inputWithCompression)
 
       // Compression should add 50μs CPU overhead
-      expect(resultWithCompression.estimatedLatencyUs).toBeGreaterThan(
-        resultNoCompression.estimatedLatencyUs!,
+      const latencyNoCompression = resultNoCompression.estimatedLatencyUs
+      const latencyWithCompression = resultWithCompression.estimatedLatencyUs
+      expect(latencyNoCompression).toBeDefined()
+      expect(latencyWithCompression).toBeDefined()
+      expect(latencyWithCompression).toBeGreaterThan(latencyNoCompression as number)
+      expect((latencyWithCompression as number) - (latencyNoCompression as number)).toBeCloseTo(
+        50,
+        -1,
       )
-      expect(
-        resultWithCompression.estimatedLatencyUs! - resultNoCompression.estimatedLatencyUs!,
-      ).toBeCloseTo(50, -1)
     })
 
     it('should add dedup CPU overhead when enabled', () => {
@@ -2128,11 +2151,12 @@ describe('Performance Engine - Nutanix DSF Performance', () => {
       const resultWithDedup = calculatePerformance(inputWithDedup)
 
       // Dedup should add 100μs CPU overhead
-      expect(resultWithDedup.estimatedLatencyUs).toBeGreaterThan(resultNoDedup.estimatedLatencyUs!)
-      expect(resultWithDedup.estimatedLatencyUs! - resultNoDedup.estimatedLatencyUs!).toBeCloseTo(
-        100,
-        -1,
-      )
+      const latencyNoDedup = resultNoDedup.estimatedLatencyUs
+      const latencyWithDedup = resultWithDedup.estimatedLatencyUs
+      expect(latencyNoDedup).toBeDefined()
+      expect(latencyWithDedup).toBeDefined()
+      expect(latencyWithDedup).toBeGreaterThan(latencyNoDedup as number)
+      expect((latencyWithDedup as number) - (latencyNoDedup as number)).toBeCloseTo(100, -1)
     })
 
     it('should accumulate compression + dedup CPU overhead when both enabled', () => {
@@ -2160,8 +2184,12 @@ describe('Performance Engine - Nutanix DSF Performance', () => {
       const resultBoth = calculatePerformance(inputBoth)
 
       // Compression (50μs) + Dedup (100μs) = 150μs additional overhead
-      expect(resultBoth.estimatedLatencyUs).toBeGreaterThan(resultNone.estimatedLatencyUs!)
-      expect(resultBoth.estimatedLatencyUs! - resultNone.estimatedLatencyUs!).toBeCloseTo(150, -1)
+      const latencyNone = resultNone.estimatedLatencyUs
+      const latencyBoth = resultBoth.estimatedLatencyUs
+      expect(latencyNone).toBeDefined()
+      expect(latencyBoth).toBeDefined()
+      expect(latencyBoth).toBeGreaterThan(latencyNone as number)
+      expect((latencyBoth as number) - (latencyNone as number)).toBeCloseTo(150, -1)
     })
 
     it('should validate compression-only overhead (no dedup)', () => {
@@ -2299,7 +2327,9 @@ describe('Performance Engine - Nutanix DSF Performance', () => {
       // Nutanix (2x media + RDMA network) should have higher latency than PowerStore (1.2x media)
       // Nutanix: 20 * 2 + 100 + 20 = 160μs
       // PowerStore: 20 * 1.2 + 10 = 34μs
-      expect(resultNutanix.estimatedLatencyUs).toBeGreaterThan(resultPowerStore.estimatedLatencyUs!)
+      const latencyPowerStoreNtx = resultPowerStore.estimatedLatencyUs
+      expect(latencyPowerStoreNtx).toBeDefined()
+      expect(resultNutanix.estimatedLatencyUs).toBeGreaterThan(latencyPowerStoreNtx as number)
     })
   })
 })
@@ -2339,7 +2369,7 @@ describe('Performance Engine - vSAN ESA bottleneck chain', () => {
 
       // Naive aggregate would be 12500 × 5 = 62500 MB/s; the refined model is higher.
       expect(networkLayer).toBeDefined()
-      expect(networkLayer!.throughputMBs).toBeGreaterThan(62_500)
+      expect(networkLayer?.throughputMBs).toBeGreaterThan(62_500)
     })
 
     it('is not flagged as the bottleneck for a small 100GbE NVMe cluster', () => {
@@ -2350,7 +2380,8 @@ describe('Performance Engine - vSAN ESA bottleneck chain', () => {
       const result = calculatePerformance(input)
       const networkLayer = result.layers.find((l) => l.name.startsWith('Network'))
 
-      expect(networkLayer!.isBottleneck).toBe(false)
+      expect(networkLayer).toBeDefined()
+      expect(networkLayer?.isBottleneck).toBe(false)
     })
 
     it('on-the-wire compression raises the effective network ceiling', () => {
@@ -2366,14 +2397,18 @@ describe('Performance Engine - vSAN ESA bottleneck chain', () => {
         vsanOptions: { ...DEFAULT_VSAN_OPTIONS, compression: false },
       }
 
-      const netWith = calculatePerformance(withCompression).layers.find((l) =>
+      const layerWith = calculatePerformance(withCompression).layers.find((l) =>
         l.name.startsWith('Network'),
-      )!.throughputMBs
-      const netWithout = calculatePerformance(withoutCompression).layers.find((l) =>
+      )
+      const layerWithout = calculatePerformance(withoutCompression).layers.find((l) =>
         l.name.startsWith('Network'),
-      )!.throughputMBs
+      )
+      expect(layerWith).toBeDefined()
+      expect(layerWithout).toBeDefined()
+      const netWith = layerWith?.throughputMBs
+      const netWithout = layerWithout?.throughputMBs
 
-      expect(netWith).toBeGreaterThan(netWithout)
+      expect(netWith).toBeGreaterThan(netWithout as number)
     })
 
     it('leaves non-vSAN topologies on the naive aggregate model', () => {
@@ -2385,7 +2420,8 @@ describe('Performance Engine - vSAN ESA bottleneck chain', () => {
       const networkLayer = result.layers.find((l) => l.name.startsWith('Network'))
 
       // Standard RAID uses the neutral model: 12500 × 5 = 62500 MB/s exactly.
-      expect(networkLayer!.throughputMBs).toBeCloseTo(62_500, 0)
+      expect(networkLayer).toBeDefined()
+      expect(networkLayer?.throughputMBs).toBeCloseTo(62_500, 0)
     })
   })
 })

--- a/tests/engines/s2d-performance.spec.ts
+++ b/tests/engines/s2d-performance.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * S2D Performance Strategy Tests
+ *
+ * Locks in the per-copy mirror write penalty: a mirror write fans out to one
+ * backend write per copy, so the penalty equals mirrorCopies (2-way = 2x, 3-way = 3x).
+ * MAP applies a small parity surcharge on top of the mirror-tier penalty (mirrorCopies + 0.5).
+ */
+
+import { describe, expect, it } from 'vitest'
+import { s2dPerformanceStrategy } from '@/engines/performance/strategies/s2d'
+
+describe('S2D Performance Strategy - getWritePenalty', () => {
+  it('two-way mirror has a 2.0x write penalty (one backend write per copy)', () => {
+    expect(s2dPerformanceStrategy.getWritePenalty('mirror', { mirrorCopies: 2 })).toBe(2.0)
+  })
+
+  it('three-way mirror has a 3.0x write penalty (one backend write per copy)', () => {
+    expect(s2dPerformanceStrategy.getWritePenalty('mirror', { mirrorCopies: 3 })).toBe(3.0)
+  })
+
+  it('simple (no redundancy) has a 1.0x write penalty', () => {
+    expect(s2dPerformanceStrategy.getWritePenalty('simple')).toBe(1.0)
+  })
+
+  it('single parity has a 3.0x write penalty', () => {
+    expect(s2dPerformanceStrategy.getWritePenalty('parity')).toBe(3.0)
+  })
+
+  it('dual parity has a 4.0x write penalty', () => {
+    expect(s2dPerformanceStrategy.getWritePenalty('dual_parity')).toBe(4.0)
+  })
+
+  it('MAP with a two-way mirror tier has a 2.5x write penalty (mirrorCopies + 0.5)', () => {
+    expect(s2dPerformanceStrategy.getWritePenalty('map', { mirrorCopies: 2 })).toBe(2.5)
+  })
+
+  it('MAP with a three-way mirror tier has a 3.5x write penalty (mirrorCopies + 0.5)', () => {
+    expect(s2dPerformanceStrategy.getWritePenalty('map', { mirrorCopies: 3 })).toBe(3.5)
+  })
+})

--- a/tests/engines/sustainability.spec.ts
+++ b/tests/engines/sustainability.spec.ts
@@ -142,9 +142,10 @@ describe('calculateSustainability', () => {
   describe('flash endurance', () => {
     it('returns flashEndurance object for SSD with dwpd > 0', () => {
       const result = calculateSustainability(baseInput)
-      expect(result.flashEndurance).toBeDefined()
-      expect(result.flashEndurance!.ratedDwpd).toBe(3)
-      expect(result.flashEndurance!.requiredDwpd).toBeGreaterThan(0)
+      const flashEndurance = result.flashEndurance
+      expect(flashEndurance).toBeDefined()
+      expect(flashEndurance?.ratedDwpd).toBe(3)
+      expect(flashEndurance?.requiredDwpd).toBeGreaterThan(0)
     })
 
     it('returns undefined flashEndurance for HDD drives', () => {
@@ -163,9 +164,11 @@ describe('calculateSustainability', () => {
 
     it('calculates utilizationPercent as (requiredDwpd / ratedDwpd) * 100', () => {
       const result = calculateSustainability(baseInput)
+      const flashEndurance = result.flashEndurance
+      expect(flashEndurance).toBeDefined()
       const expected =
-        (result.flashEndurance!.requiredDwpd / result.flashEndurance!.ratedDwpd) * 100
-      expect(result.flashEndurance!.utilizationPercent).toBeCloseTo(expected, 2)
+        ((flashEndurance?.requiredDwpd ?? 0) / (flashEndurance?.ratedDwpd ?? 1)) * 100
+      expect(flashEndurance?.utilizationPercent).toBeCloseTo(expected, 2)
     })
 
     it('sets surviveProject true when expected life > project years', () => {
@@ -175,9 +178,10 @@ describe('calculateSustainability', () => {
         dailyWriteVolume: 1_000_000_000, // 1 GB/day, very low
       }
       const result = calculateSustainability(lowWriteInput)
-      expect(result.flashEndurance).toBeDefined()
-      expect(result.flashEndurance!.surviveProject).toBe(true)
-      expect(result.flashEndurance!.expectedLifeYears).toBeGreaterThan(5)
+      const flashEndurance = result.flashEndurance
+      expect(flashEndurance).toBeDefined()
+      expect(flashEndurance?.surviveProject).toBe(true)
+      expect(flashEndurance?.expectedLifeYears).toBeGreaterThan(5)
     })
   })
 

--- a/tests/engines/volumetry.spec.ts
+++ b/tests/engines/volumetry.spec.ts
@@ -1492,6 +1492,68 @@ describe('Volumetry Engine - Microsoft S2D', () => {
 
       expect(Math.abs(reserveDifference - expectedReserve)).toBeLessThan(tolerance)
     })
+
+    it('should cap the drive_failure reserve at 4 drives even with 8 fault domains', () => {
+      // 8 nodes × 10 drives = 80 drives, 2-way mirror — far more capacity than the reserve.
+      const inputWithReserve = createInput(80, { type: 's2d', level: 'mirror' })
+      inputWithReserve.s2dOptions = {
+        ...DEFAULT_S2D_OPTIONS,
+        rebuildReserve: true,
+        reserveStrategy: 'drive_failure',
+        faultDomains: 8,
+      }
+
+      const inputWithoutReserve = createInput(80, { type: 's2d', level: 'mirror' })
+      inputWithoutReserve.s2dOptions = {
+        ...DEFAULT_S2D_OPTIONS,
+        rebuildReserve: false,
+        reserveStrategy: 'drive_failure',
+        faultDomains: 8,
+      }
+
+      const resultWith = calculateVolumetry(inputWithReserve)
+      const resultWithout = calculateVolumetry(inputWithoutReserve)
+
+      const reserveDifference = resultWithout.usableCapacity - resultWith.usableCapacity
+
+      // Reserve is min(faultDomains, 4) = 4 drives, NOT 8 drives.
+      const cappedReserve = 4 * testDrive.capacity_raw
+      const tolerance = cappedReserve * 0.1 // 10% (filesystem overhead on the reserved slice)
+
+      expect(Math.abs(reserveDifference - cappedReserve)).toBeLessThan(tolerance)
+      // Prove the cap held: difference is well below an uncapped 8-drive reserve.
+      expect(reserveDifference).toBeLessThan(5 * testDrive.capacity_raw)
+    })
+
+    it('should reserve 3 drives worth for 3 fault domains (below the cap)', () => {
+      // 3 nodes × 10 drives = 30 drives, 2-way mirror.
+      const inputWithReserve = createInput(30, { type: 's2d', level: 'mirror' })
+      inputWithReserve.s2dOptions = {
+        ...DEFAULT_S2D_OPTIONS,
+        rebuildReserve: true,
+        reserveStrategy: 'drive_failure',
+        faultDomains: 3,
+      }
+
+      const inputWithoutReserve = createInput(30, { type: 's2d', level: 'mirror' })
+      inputWithoutReserve.s2dOptions = {
+        ...DEFAULT_S2D_OPTIONS,
+        rebuildReserve: false,
+        reserveStrategy: 'drive_failure',
+        faultDomains: 3,
+      }
+
+      const resultWith = calculateVolumetry(inputWithReserve)
+      const resultWithout = calculateVolumetry(inputWithoutReserve)
+
+      const reserveDifference = resultWithout.usableCapacity - resultWith.usableCapacity
+
+      // 3 < 4, so the cap does not apply: reserve is 3 drives' worth.
+      const expectedReserve = 3 * testDrive.capacity_raw
+      const tolerance = expectedReserve * 0.1
+
+      expect(Math.abs(reserveDifference - expectedReserve)).toBeLessThan(tolerance)
+    })
   })
 })
 

--- a/tests/utils/connectivityConstraints.spec.ts
+++ b/tests/utils/connectivityConstraints.spec.ts
@@ -13,6 +13,7 @@ import {
   getConnectivityConstraint,
 } from '@utils/connectivityConstraints'
 import { describe, expect, it } from 'vitest'
+import { DEFAULT_NUTANIX_OPTIONS, DEFAULT_VSAN_OPTIONS } from '@/types/topology'
 
 describe('connectivityConstraints', () => {
   describe('NVMe-only topologies', () => {
@@ -58,7 +59,7 @@ describe('connectivityConstraints', () => {
     it('returns flash_only for nutanix with all-flash cluster type', () => {
       const input: ConnectivityConstraintInput = {
         topologyType: 'nutanix',
-        nutanixOptions: { clusterType: 'all-flash' } as any,
+        nutanixOptions: { ...DEFAULT_NUTANIX_OPTIONS, clusterType: 'all-flash' },
       }
       const result = getConnectivityConstraint(input)
       expect(result.constraint).toBe('flash_only')
@@ -69,7 +70,7 @@ describe('connectivityConstraints', () => {
     it('returns flash_only for vsan_osa with all-flash disk group mode', () => {
       const input: ConnectivityConstraintInput = {
         topologyType: 'vsan_osa',
-        vsanOptions: { diskGroupMode: 'all-flash' } as any,
+        vsanOptions: { ...DEFAULT_VSAN_OPTIONS, diskGroupMode: 'all-flash' },
       }
       const result = getConnectivityConstraint(input)
       expect(result.constraint).toBe('flash_only')
@@ -101,7 +102,7 @@ describe('connectivityConstraints', () => {
     it('returns none for nutanix with hybrid cluster type', () => {
       const input: ConnectivityConstraintInput = {
         topologyType: 'nutanix',
-        nutanixOptions: { clusterType: 'hybrid' } as any,
+        nutanixOptions: { ...DEFAULT_NUTANIX_OPTIONS, clusterType: 'hybrid' },
       }
       const result = getConnectivityConstraint(input)
       expect(result.constraint).toBe('none')
@@ -111,7 +112,7 @@ describe('connectivityConstraints', () => {
     it('returns none for vsan_osa without all-flash disk group mode', () => {
       const input: ConnectivityConstraintInput = {
         topologyType: 'vsan_osa',
-        vsanOptions: { diskGroupMode: 'hybrid' } as any,
+        vsanOptions: { ...DEFAULT_VSAN_OPTIONS, diskGroupMode: 'hybrid' },
       }
       const result = getConnectivityConstraint(input)
       expect(result.constraint).toBe('none')

--- a/tests/utils/urlStorage.spec.ts
+++ b/tests/utils/urlStorage.spec.ts
@@ -65,7 +65,7 @@ describe('URL Storage - Serialization Roundtrip', () => {
 
     // Extract from mocked replaceState call
     expect(mockHistory.replaceState).toHaveBeenCalled()
-    const newUrl = mockHistory.replaceState.mock.calls[0]![2]
+    const newUrl = mockHistory.replaceState.mock.calls[0]?.[2]
     const hashPart = newUrl.split('#')[1]
     mockLocation.hash = `#${hashPart}`
 
@@ -92,7 +92,7 @@ describe('URL Storage - Serialization Roundtrip', () => {
 
     // Roundtrip
     urlHashStorage.setItem(stateKey, JSON.stringify(raidConfig))
-    const newUrl = mockHistory.replaceState.mock.calls[0]![2]
+    const newUrl = mockHistory.replaceState.mock.calls[0]?.[2]
     mockLocation.hash = `#${newUrl.split('#')[1]}`
     const retrieved = urlHashStorage.getItem(stateKey)
 
@@ -128,7 +128,7 @@ describe('URL Storage - Serialization Roundtrip', () => {
 
     // Roundtrip
     urlHashStorage.setItem(stateKey, JSON.stringify(zfsConfig))
-    const newUrl = mockHistory.replaceState.mock.calls[0]![2]
+    const newUrl = mockHistory.replaceState.mock.calls[0]?.[2]
     mockLocation.hash = `#${newUrl.split('#')[1]}`
     const retrieved = urlHashStorage.getItem(stateKey)
 
@@ -161,7 +161,7 @@ describe('URL Storage - Serialization Roundtrip', () => {
 
     // Roundtrip
     urlHashStorage.setItem(stateKey, JSON.stringify(vsanConfig))
-    const newUrl = mockHistory.replaceState.mock.calls[0]![2]
+    const newUrl = mockHistory.replaceState.mock.calls[0]?.[2]
     mockLocation.hash = `#${newUrl.split('#')[1]}`
     const retrieved = urlHashStorage.getItem(stateKey)
 
@@ -209,7 +209,7 @@ describe('URL Storage - Serialization Roundtrip', () => {
 
     // Roundtrip
     urlHashStorage.setItem(stateKey, JSON.stringify(completeConfig))
-    const newUrl = mockHistory.replaceState.mock.calls[0]![2]
+    const newUrl = mockHistory.replaceState.mock.calls[0]?.[2]
     mockLocation.hash = `#${newUrl.split('#')[1]}`
     const retrieved = urlHashStorage.getItem(stateKey)
 
@@ -234,7 +234,7 @@ describe('URL Storage - Serialization Roundtrip', () => {
 
     // Roundtrip
     urlHashStorage.setItem(stateKey, minimalConfig)
-    const newUrl = mockHistory.replaceState.mock.calls[0]![2]
+    const newUrl = mockHistory.replaceState.mock.calls[0]?.[2]
     mockLocation.hash = `#${newUrl.split('#')[1]}`
     const retrieved = urlHashStorage.getItem(stateKey)
 
@@ -256,7 +256,7 @@ describe('URL Storage - Serialization Roundtrip', () => {
 
     // Roundtrip
     urlHashStorage.setItem(stateKey, specialCharsConfig)
-    const newUrl = mockHistory.replaceState.mock.calls[0]![2]
+    const newUrl = mockHistory.replaceState.mock.calls[0]?.[2]
     mockLocation.hash = `#${newUrl.split('#')[1]}`
     const retrieved = urlHashStorage.getItem(stateKey)
 
@@ -308,7 +308,7 @@ describe('URL Storage - Serialization Roundtrip', () => {
 
     // Roundtrip
     urlHashStorage.setItem(stateKey, largeConfigStr)
-    const newUrl = mockHistory.replaceState.mock.calls[0]![2]
+    const newUrl = mockHistory.replaceState.mock.calls[0]?.[2]
     mockLocation.hash = `#${newUrl.split('#')[1]}`
     const retrieved = urlHashStorage.getItem(stateKey)
 
@@ -328,7 +328,7 @@ describe('URL Storage - Serialization Roundtrip', () => {
     })
 
     urlHashStorage.setItem(stateKey, config)
-    const newUrl = mockHistory.replaceState.mock.calls[0]![2]
+    const newUrl = mockHistory.replaceState.mock.calls[0]?.[2]
 
     // Snapshot the URL format
     expect(newUrl).toMatchSnapshot()
@@ -373,7 +373,7 @@ describe('URL Storage - Serialization Roundtrip', () => {
 
     // Roundtrip
     urlHashStorage.setItem(stateKey, JSON.stringify(maxConfig))
-    const newUrl = mockHistory.replaceState.mock.calls[0]![2]
+    const newUrl = mockHistory.replaceState.mock.calls[0]?.[2]
     mockLocation.hash = `#${newUrl.split('#')[1]}`
     const retrieved = urlHashStorage.getItem(stateKey)
 
@@ -441,7 +441,7 @@ describe('URL Storage - Backward Compatibility', () => {
 
     // First serialization
     urlHashStorage.setItem(stateKey, config)
-    const url1 = mockHistory.replaceState.mock.calls[0]![2]
+    const url1 = mockHistory.replaceState.mock.calls[0]?.[2]
     mockLocation.hash = `#${url1.split('#')[1]}`
 
     // Retrieve and re-serialize
@@ -450,7 +450,7 @@ describe('URL Storage - Backward Compatibility', () => {
     mockHistory.replaceState.mockClear()
     if (retrieved) {
       urlHashStorage.setItem(stateKey, expectSyncString(retrieved))
-      const url2 = mockHistory.replaceState.mock.calls[0]![2]
+      const url2 = mockHistory.replaceState.mock.calls[0]?.[2]
 
       // URLs should be identical (stable serialization)
       expect(url1).toBe(url2)
@@ -501,7 +501,7 @@ describe('URL Storage - removeItem', () => {
 
     // Add item
     urlHashStorage.setItem(stateKey, config)
-    const urlWithItem = mockHistory.replaceState.mock.calls[0]![2]
+    const urlWithItem = mockHistory.replaceState.mock.calls[0]?.[2]
     mockLocation.hash = `#${urlWithItem.split('#')[1]}`
 
     // Remove item
@@ -510,7 +510,7 @@ describe('URL Storage - removeItem', () => {
 
     // Verify removal
     expect(mockHistory.replaceState).toHaveBeenCalled()
-    const urlAfterRemove = mockHistory.replaceState.mock.calls[0]![2]
+    const urlAfterRemove = mockHistory.replaceState.mock.calls[0]?.[2]
     expect(urlAfterRemove).not.toContain(stateKey)
   })
 
@@ -519,7 +519,7 @@ describe('URL Storage - removeItem', () => {
 
     urlHashStorage.removeItem('key1')
 
-    const newUrl = mockHistory.replaceState.mock.calls[0]![2]
+    const newUrl = mockHistory.replaceState.mock.calls[0]?.[2]
     expect(newUrl).toContain('key2=value2')
     expect(newUrl).not.toContain('key1')
   })
@@ -531,7 +531,7 @@ describe('URL Storage - removeItem', () => {
 
     urlHashStorage.removeItem('storage-state')
 
-    const newUrl = mockHistory.replaceState.mock.calls[0]![2]
+    const newUrl = mockHistory.replaceState.mock.calls[0]?.[2]
     expect(newUrl).toBe('/simulator')
     expect(newUrl).not.toContain('#')
   })

--- a/tests/utils/validators.spec.ts
+++ b/tests/utils/validators.spec.ts
@@ -11,8 +11,11 @@ import type { ControllerType } from '@/types/topology'
 import {
   DEFAULT_NETAPP_OPTIONS,
   DEFAULT_POWERFLEX_OPTIONS,
+  DEFAULT_S2D_OPTIONS,
   DEFAULT_SYNOLOGY_OPTIONS,
   DEFAULT_ZFS_OPTIONS,
+  type S2DOptions,
+  type S2DTopology,
   type Topology,
 } from '@/types/topology'
 import {
@@ -743,8 +746,12 @@ describe('Validators - Helper Functions', () => {
     if (alerts.length > 1) {
       const severityOrder = ['error', 'warning', 'info']
       for (let i = 0; i < alerts.length - 1; i++) {
-        const currentIndex = severityOrder.indexOf(alerts[i]!.severity)
-        const nextIndex = severityOrder.indexOf(alerts[i + 1]!.severity)
+        const current = alerts[i]
+        const next = alerts[i + 1]
+        expect(current).toBeDefined()
+        expect(next).toBeDefined()
+        const currentIndex = severityOrder.indexOf(current?.severity ?? 'info')
+        const nextIndex = severityOrder.indexOf(next?.severity ?? 'info')
         expect(currentIndex).toBeLessThanOrEqual(nextIndex)
       }
     }
@@ -904,5 +911,109 @@ describe('Validators - validateOrThrow', () => {
       level: 'powerflex_medium_2way',
     })
     expect(() => validateOrThrow(input)).toThrow(/HDD drives are no longer supported/i)
+  })
+})
+
+describe('Validators - S2D Resiliency', () => {
+  // Build a valid S2D ValidationInput. An HBA controller is used so the generic
+  // RAID_CONTROLLER_INCOMPATIBLE alert never fires; driveCount stays >= 4 so
+  // S2D_MIN_DRIVES never fires. We then assert only on the specific S2D codes.
+  function createS2DInput(
+    level: S2DTopology,
+    overrides: Partial<S2DOptions>,
+    driveCount = 8,
+  ): ValidationInput {
+    const input = createValidationInput(
+      testHdd,
+      driveCount,
+      { type: 's2d', level },
+      1,
+      'lsi_9500', // HBA (IT mode) — S2D requires an HBA
+    )
+    input.s2dOptions = {
+      ...DEFAULT_S2D_OPTIONS,
+      rebuildReserve: true,
+      reserveStrategy: 'drive_failure',
+      storageTiers: false,
+      ...overrides,
+    }
+    return input
+  }
+
+  const minNodeErrorCodes = [
+    'S2D_3WAY_MIN_NODES',
+    'S2D_PARITY_MIN_NODES',
+    'S2D_DUAL_PARITY_MIN_NODES',
+    'S2D_MAP_MIN_NODES',
+  ]
+
+  it('flags three-way mirror with fewer than 3 nodes (S2D_3WAY_MIN_NODES)', () => {
+    const alerts = validateConfiguration(
+      createS2DInput('mirror', { mirrorCopies: 3, faultDomains: 2 }),
+    )
+    const alert = alerts.find((a) => a.code === 'S2D_3WAY_MIN_NODES')
+    expect(alert).toBeDefined()
+    expect(alert?.severity).toBe('error')
+  })
+
+  it('flags single parity with fewer than 3 nodes (S2D_PARITY_MIN_NODES)', () => {
+    const alerts = validateConfiguration(createS2DInput('parity', { faultDomains: 2 }))
+    const alert = alerts.find((a) => a.code === 'S2D_PARITY_MIN_NODES')
+    expect(alert).toBeDefined()
+    expect(alert?.severity).toBe('error')
+  })
+
+  it('flags dual parity with fewer than 4 nodes (S2D_DUAL_PARITY_MIN_NODES)', () => {
+    const alerts = validateConfiguration(createS2DInput('dual_parity', { faultDomains: 3 }))
+    const alert = alerts.find((a) => a.code === 'S2D_DUAL_PARITY_MIN_NODES')
+    expect(alert).toBeDefined()
+    expect(alert?.severity).toBe('error')
+  })
+
+  it('flags mirror-accelerated parity with fewer than 4 nodes (S2D_MAP_MIN_NODES)', () => {
+    const alerts = validateConfiguration(createS2DInput('map', { faultDomains: 3 }))
+    const alert = alerts.find((a) => a.code === 'S2D_MAP_MIN_NODES')
+    expect(alert).toBeDefined()
+    expect(alert?.severity).toBe('error')
+  })
+
+  it('discourages single parity for clustered S2D (S2D_SINGLE_PARITY_DISCOURAGED)', () => {
+    const alerts = validateConfiguration(createS2DInput('parity', { faultDomains: 4 }))
+    const alert = alerts.find((a) => a.code === 'S2D_SINGLE_PARITY_DISCOURAGED')
+    expect(alert).toBeDefined()
+    expect(alert?.severity).toBe('warning')
+    // 4 nodes satisfy the parity node minimum, so the node-count error must not fire.
+    expect(alerts.find((a) => a.code === 'S2D_PARITY_MIN_NODES')).toBeUndefined()
+  })
+
+  it('recommends nested resiliency for 2-node clusters (S2D_2NODE_NESTED_RECOMMENDED)', () => {
+    const alerts = validateConfiguration(
+      createS2DInput('mirror', { mirrorCopies: 2, faultDomains: 2 }),
+    )
+    const alert = alerts.find((a) => a.code === 'S2D_2NODE_NESTED_RECOMMENDED')
+    expect(alert).toBeDefined()
+    expect(alert?.severity).toBe('warning')
+  })
+
+  it('recommends three-way mirror for production HA on a two-way mirror (S2D_3WAY_RECOMMENDED)', () => {
+    const alerts = validateConfiguration(
+      createS2DInput('mirror', { mirrorCopies: 2, faultDomains: 4 }),
+    )
+    const alert = alerts.find((a) => a.code === 'S2D_3WAY_RECOMMENDED')
+    expect(alert).toBeDefined()
+    expect(alert?.severity).toBe('info')
+  })
+
+  it('produces no resiliency errors for a valid three-way mirror on 4 nodes', () => {
+    const alerts = validateConfiguration(
+      createS2DInput('mirror', { mirrorCopies: 3, faultDomains: 4 }),
+    )
+    for (const code of minNodeErrorCodes) {
+      expect(alerts.find((a) => a.code === code)).toBeUndefined()
+    }
+    // The 3-way recommendation only fires for two-way mirrors.
+    expect(alerts.find((a) => a.code === 'S2D_3WAY_RECOMMENDED')).toBeUndefined()
+    // A valid config has no blocking errors at all.
+    expect(hasBlockingErrors(alerts)).toBe(false)
   })
 })

--- a/tests/workers/resilience.spec.ts
+++ b/tests/workers/resilience.spec.ts
@@ -160,7 +160,9 @@ describe('Resilience Worker - Survival Rate Ordering', () => {
     // Note: Using 0.95 multiplier (5% tolerance) for stochastic variance
     // See "Statistical Accuracy" describe block for tolerance guidelines
     for (let i = 1; i < survivalRates.length; i++) {
-      expect(survivalRates[i]).toBeGreaterThanOrEqual(survivalRates[i - 1]! * 0.95)
+      const prevRate = survivalRates[i - 1]
+      expect(prevRate).toBeDefined()
+      expect(survivalRates[i]).toBeGreaterThanOrEqual((prevRate ?? 0) * 0.95)
     }
   })
 })
@@ -277,7 +279,7 @@ describe('Resilience Worker - Progress Reporting', () => {
     expect(progressCalls.length).toBeGreaterThan(0)
 
     // Progress should show completed and total
-    const lastProgress = progressCalls[progressCalls.length - 1]![0].payload
+    const lastProgress = progressCalls[progressCalls.length - 1]?.[0].payload
     expect(lastProgress.completed).toBe(1000)
     expect(lastProgress.total).toBe(1000)
   })
@@ -306,7 +308,7 @@ describe('Resilience Worker - Progress Reporting', () => {
     expect(resultCalls.length).toBe(1)
 
     // Result should have all expected fields
-    const result = resultCalls[0]![0].payload
+    const result = resultCalls[0]?.[0].payload
     expect(result).toHaveProperty('survivalRate')
     expect(result).toHaveProperty('survivalPercent')
     expect(result).toHaveProperty('averageRebuildTimeHours')


### PR DESCRIPTION
## Summary

Audited S2D configuration and numbers against **Microsoft Learn** (Storage Spaces Direct fault tolerance & nested resiliency) and fixed the divergences. Also expanded the in-app guide with dedicated, best-practice S2D and vSAN ESA content in all four languages. Folds into the upcoming **1.8.0** release.

## S2D correctness fixes
- **Node-minimum validation** per resiliency type (new `validateS2DResiliency`): three-way mirror & single parity require ≥ 3 fault domains, dual parity & MAP require ≥ 4 — each an error alert.
- **`faultDomains` bounds** tightened from 1–100 to **2–16** (Microsoft cluster range).
- **Mirror write penalty** now scales with `mirrorCopies` (two-way = 2×, three-way = 3×, MAP = `mirrorCopies + 0.5`); `s2dOptions` threaded through the performance engine.
- **Rebuild reserve** follows Microsoft's rule — 1 capacity drive per server, **capped at 4 drives**, clamped to available post-parity capacity (fixes a tiny-cluster under-count); default strategy now `drive_failure`.
- **Best-practice alerts**: single parity discouraged for clustered S2D, nested resiliency recommended for 2-node clusters, three-way mirror recommended for production HA.

## Guide (Part B)
- Expanded **S2D** and **vSAN ESA** platform notes (resiliency/efficiency, replication, reserve, nested resiliency, ESA log-structured EC) in `en/fr/de/it`; corrected the stale S2D reserve text. vSAN ESA content is VMware-canonical; two model divergences are recorded as **Known limitations** in the changelog (not changed here, per scope).

## Verification
- `npm run typecheck` ✅ · `biome check` ✅ (0 issues in tracked files) · `vitest` ✅ **928 passed**
- Includes new tests for the validator alerts, per-copy write penalty, and reserve cap; also clears pre-existing Biome lint warnings across test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer in-app guidance for VMware vSAN ESA and Storage Spaces Direct, including resiliency, efficiency, rebuild reserve, and performance details.
  * Added S2D resiliency alerts to help surface configuration issues earlier.

* **Bug Fixes**
  * Corrected S2D reserve, rebuild, and capacity calculations.
  * Improved write-penalty and performance modeling for S2D mirror-based setups.
  * Tightened S2D fault-domain limits and related validation.
  * Fixed several vSAN and ECC capacity/performance accuracy issues.

* **Documentation**
  * Expanded release notes and translated platform guidance across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->