### PR TITLE
fix(vsan): align ESA RAID-5/6 stripe widths with VMware docs (1.9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.1] - 2026-06-26
+
+### Fixed
+- **vSAN ESA adaptive RAID-5 threshold now matches VMware.** The 4+1 stripe (80% efficiency) now engages at ≥ 6 hosts (host-count only) as VMware documents — previously it required ≥ 5 hosts *and* ≥ 100 drives. 3–5 host clusters correctly stay 2+1 (67%). Resolves a known limitation noted in 1.9.0.
+- **vSAN ESA RAID-6 is now a fixed 4+2 stripe.** ESA adapts only RAID-5; RAID-6 stays 4+2 (67% efficiency) regardless of cluster size. Removed the incorrect 6+2 (75%) scheme the model applied at ≥ 8 hosts. Resolves a known limitation noted in 1.9.0.
+
 ## [1.9.0] - 2026-06-25
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "raidy",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "raidy",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "dependencies": {
         "d3-sankey": "^0.12.3",
         "dompurify": "^3.4.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raidy",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.9.1",
   "type": "module",
   "description": "Browser-based simulator for modern storage infrastructure (RAID, ZFS, vSAN, S2D, Nutanix, Dell, NetApp, Ceph, Synology). 100% client-side.",
   "scripts": {

--- a/src/engines/volumetry/strategies/vsan.ts
+++ b/src/engines/volumetry/strategies/vsan.ts
@@ -56,19 +56,17 @@ export const vsanStrategy: VolumetryStrategy = {
         return 0.5
 
       case 'vsan_esa_raid5': {
-        // Adaptive RAID-5: stripe width scales with cluster size
-        // 4+1 requires min 5 hosts and sufficient drives (120+ with 24 slots/server)
-        // 2+1 for smaller clusters
-        const canUse4Plus1 = serverCount >= 5 && driveCount >= serverCount * 20
+        // Adaptive RAID-5: vSAN picks the stripe width by host count.
+        // 4+1 (80%) for 6+ hosts, 2+1 (67%) for 3-5 hosts. Host-count only —
+        // VMware documents the threshold as >= 6 hosts (a spare fault domain).
+        const canUse4Plus1 = serverCount >= 6
         return canUse4Plus1 ? 4 / 5 : 2 / 3
       }
 
-      case 'vsan_esa_raid6': {
-        // Adaptive RAID-6: stripe width scales with cluster size
-        // 6+2 requires min 8 hosts, 4+2 for smaller clusters
-        const canUse6Plus2 = serverCount >= 8 && driveCount >= serverCount * 20
-        return canUse6Plus2 ? 6 / 8 : 4 / 6
-      }
+      case 'vsan_esa_raid6':
+        // RAID-6 is a fixed 4+2 erasure-coding stripe (67%) regardless of
+        // cluster size; ESA only adapts RAID-5. Minimum 6 hosts.
+        return 4 / 6
 
       default:
         // Default to 2+1 RAID-5 efficiency

--- a/tests/engines/volumetry.spec.ts
+++ b/tests/engines/volumetry.spec.ts
@@ -1202,7 +1202,9 @@ describe('Volumetry Engine - vSAN Topologies', () => {
     })
 
     it('RAID-5: should use 4+1 scheme (80%) for clusters with ≥6 hosts', () => {
-      const input = createInput(144, { type: 'vsan_esa', level: 'vsan_esa_raid5' })
+      // 96 drives is below the old `serverCount * 20` (=120) cutoff, so this
+      // case only reaches 4+1 under the new host-count-only rule.
+      const input = createInput(96, { type: 'vsan_esa', level: 'vsan_esa_raid5' })
       input.serverCount = 6 // Meets the VMware 4+1 threshold (host-count only)
 
       const result = calculateVolumetry(input)

--- a/tests/engines/volumetry.spec.ts
+++ b/tests/engines/volumetry.spec.ts
@@ -1189,22 +1189,21 @@ describe('Volumetry Engine - vSAN Topologies', () => {
       expect(efficiencyDecimal).toBeLessThan(0.7)
     })
 
-    it('RAID-5: should use 2+1 scheme (67%) for clusters with insufficient drives', () => {
-      const input = createInput(50, { type: 'vsan_esa', level: 'vsan_esa_raid5' })
-      input.serverCount = 5 // Meets host threshold
-      // But only 50 drives (need 5 * 20 = 100+ for 4+1)
+    it('RAID-5: should still use 2+1 scheme (67%) at 5 hosts (below the 6-host threshold)', () => {
+      const input = createInput(120, { type: 'vsan_esa', level: 'vsan_esa_raid5' })
+      input.serverCount = 5 // One below the 4+1 threshold
 
       const result = calculateVolumetry(input)
 
-      // Should use 2+1 scheme = 66.67% efficiency
+      // Adaptive RAID-5 switches to 4+1 only at 6+ hosts, so 5 hosts stays 2+1
       const efficiencyDecimal = result.efficiency / 100
       expect(efficiencyDecimal).toBeGreaterThan(0.64)
       expect(efficiencyDecimal).toBeLessThan(0.7)
     })
 
-    it('RAID-5: should use 4+1 scheme (80%) for clusters with ≥5 hosts and 100+ drives', () => {
-      const input = createInput(120, { type: 'vsan_esa', level: 'vsan_esa_raid5' })
-      input.serverCount = 5 // Meets threshold
+    it('RAID-5: should use 4+1 scheme (80%) for clusters with ≥6 hosts', () => {
+      const input = createInput(144, { type: 'vsan_esa', level: 'vsan_esa_raid5' })
+      input.serverCount = 6 // Meets the VMware 4+1 threshold (host-count only)
 
       const result = calculateVolumetry(input)
 
@@ -1214,9 +1213,9 @@ describe('Volumetry Engine - vSAN Topologies', () => {
       expect(efficiencyDecimal).toBeLessThan(0.83)
     })
 
-    it('RAID-6: should use 4+2 scheme (67%) for clusters with <8 hosts', () => {
+    it('RAID-6: should use a fixed 4+2 scheme (67%) at the 6-host minimum', () => {
       const input = createInput(28, { type: 'vsan_esa', level: 'vsan_esa_raid6' })
-      input.serverCount = 7 // Below threshold
+      input.serverCount = 6
 
       const result = calculateVolumetry(input)
 
@@ -1226,16 +1225,16 @@ describe('Volumetry Engine - vSAN Topologies', () => {
       expect(efficiencyDecimal).toBeLessThan(0.7)
     })
 
-    it('RAID-6: should use 6+2 scheme (75%) for clusters with ≥8 hosts and 160+ drives', () => {
+    it('RAID-6: should stay fixed 4+2 (67%) regardless of cluster size (no 6+2)', () => {
       const input = createInput(160, { type: 'vsan_esa', level: 'vsan_esa_raid6' })
-      input.serverCount = 8 // Meets threshold
+      input.serverCount = 8 // Large cluster — ESA RAID-6 does not widen the stripe
 
       const result = calculateVolumetry(input)
 
-      // Should use 6+2 scheme = 6/8 = 75% efficiency
+      // RAID-6 remains 4+2 = 4/6 = 66.67% (only RAID-5 is adaptive in ESA)
       const efficiencyDecimal = result.efficiency / 100
-      expect(efficiencyDecimal).toBeGreaterThan(0.72)
-      expect(efficiencyDecimal).toBeLessThan(0.78)
+      expect(efficiencyDecimal).toBeGreaterThan(0.64)
+      expect(efficiencyDecimal).toBeLessThan(0.7)
     })
   })
 
@@ -1246,8 +1245,8 @@ describe('Volumetry Engine - vSAN Topologies', () => {
     it('vSAN ESA RAID-5 efficiency should increase with cluster size (adaptive)', () => {
       fc.assert(
         fc.property(
-          fc.integer({ min: 3, max: 4 }), // Small cluster
-          fc.integer({ min: 5, max: 10 }), // Large cluster
+          fc.integer({ min: 3, max: 5 }), // Small cluster (2+1, below the 6-host 4+1 threshold)
+          fc.integer({ min: 6, max: 10 }), // Large cluster (4+1)
           fc.integer({ min: 1_000_000_000_000, max: 5_000_000_000_000 }), // Drive size
           (smallServerCount, largeServerCount, driveSize) => {
             const testDrive: Drive = {
@@ -4119,7 +4118,7 @@ describe('Volumetry Engine - Error Handling', () => {
     })
   })
 
-  describe('Volumetry Engine - vSAN ESA RAID-6 Adaptive Stripe Width', () => {
+  describe('Volumetry Engine - vSAN ESA RAID-6 Fixed 4+2 Stripe Width', () => {
     it('should use 4+2 for small clusters with 4 servers (66.7% efficiency)', () => {
       const input = createInput(80, { type: 'vsan_esa', level: 'vsan_esa_raid6' })
       input.serverCount = 4 // Below 8-server threshold
@@ -4159,43 +4158,40 @@ describe('Volumetry Engine - Error Handling', () => {
       expect(efficiencyDecimal).toBeLessThan(0.7)
     })
 
-    it('should use 6+2 for large clusters (8 servers, 160 drives = 20 drives/server)', () => {
+    it('should stay 4+2 for large clusters (8 servers, 160 drives) — no 6+2 in ESA', () => {
       const input = createInput(160, { type: 'vsan_esa', level: 'vsan_esa_raid6' })
-      input.serverCount = 8 // Meets threshold
+      input.serverCount = 8
 
       const result = calculateVolumetry(input)
 
-      // 8 servers AND 160/8 = 20 drives/server: uses 6+2 configuration
-      // 6+2: 6/(6+2) = 75% efficiency
+      // ESA RAID-6 is a fixed 4+2 stripe regardless of cluster size = 66.7%
       const efficiencyDecimal = result.efficiency / 100
-      expect(efficiencyDecimal).toBeGreaterThan(0.72)
-      expect(efficiencyDecimal).toBeLessThan(0.78)
+      expect(efficiencyDecimal).toBeGreaterThan(0.64)
+      expect(efficiencyDecimal).toBeLessThan(0.7)
     })
 
-    it('should use 6+2 for very large clusters (12 servers, 240 drives = 20 drives/server)', () => {
+    it('should stay 4+2 for very large clusters (12 servers, 240 drives)', () => {
       const input = createInput(240, { type: 'vsan_esa', level: 'vsan_esa_raid6' })
-      input.serverCount = 12 // Well above threshold
+      input.serverCount = 12
 
       const result = calculateVolumetry(input)
 
-      // 12 servers AND 240/12 = 20 drives/server: uses 6+2 configuration
-      // 6+2: 6/(6+2) = 75% efficiency
+      // Still 4+2 = 66.7% (only RAID-5 adapts its stripe width in ESA)
       const efficiencyDecimal = result.efficiency / 100
-      expect(efficiencyDecimal).toBeGreaterThan(0.72)
-      expect(efficiencyDecimal).toBeLessThan(0.78)
+      expect(efficiencyDecimal).toBeGreaterThan(0.64)
+      expect(efficiencyDecimal).toBeLessThan(0.7)
     })
 
-    it('should use 6+2 when both thresholds met (10 servers, 250 drives = 25 drives/server)', () => {
+    it('should stay 4+2 regardless of drives/server (10 servers, 250 drives)', () => {
       const input = createInput(250, { type: 'vsan_esa', level: 'vsan_esa_raid6' })
-      input.serverCount = 10 // Above threshold
+      input.serverCount = 10
 
       const result = calculateVolumetry(input)
 
-      // 10 servers AND 250/10 = 25 drives/server (both thresholds met): uses 6+2
-      // 6+2: 6/(6+2) = 75% efficiency
+      // Drive density no longer influences the stripe width — RAID-6 is fixed 4+2
       const efficiencyDecimal = result.efficiency / 100
-      expect(efficiencyDecimal).toBeGreaterThan(0.72)
-      expect(efficiencyDecimal).toBeLessThan(0.78)
+      expect(efficiencyDecimal).toBeGreaterThan(0.64)
+      expect(efficiencyDecimal).toBeLessThan(0.7)
     })
   })
 

--- a/tests/fixtures/vsan-vectors.ts
+++ b/tests/fixtures/vsan-vectors.ts
@@ -217,12 +217,13 @@ export const vsanEsaVectors: VsanTestVector[] = [
     url: 'https://core.vmware.com/blog/vmware-vsan-8-adaptive-raid-5-erasure-coding',
   },
   {
-    name: 'vSAN ESA RAID-5: 5 hosts, 120 drives - Large cluster (4+1)',
+    name: 'vSAN ESA RAID-5: 5 hosts, 120 drives - Below 4+1 threshold (2+1)',
     level: 'vsan_esa_raid5',
     drives: 120,
     driveSize: TB,
     serverCount: 5,
-    expectedEfficiency: 0.8, // 80% efficiency (4+1 scheme)
+    // Adaptive RAID-5 stays 2+1 until 6 hosts (VMware host-count threshold)
+    expectedEfficiency: 0.667, // 67% efficiency (2+1 scheme)
     tolerance: 0.03,
     source: 'VMware vSAN ESA Adaptive RAID',
     url: 'https://core.vmware.com/blog/vmware-vsan-8-adaptive-raid-5-erasure-coding',
@@ -240,7 +241,7 @@ export const vsanEsaVectors: VsanTestVector[] = [
   },
 
   // ============================================================
-  // vSAN ESA RAID-6 - Adaptive: 4+2 (67%) or 6+2 (75%)
+  // vSAN ESA RAID-6 - Fixed 4+2 (67%) regardless of cluster size
   // ============================================================
   {
     name: 'vSAN ESA RAID-6: 6 hosts, 24 drives - Small cluster (4+2)',
@@ -265,23 +266,25 @@ export const vsanEsaVectors: VsanTestVector[] = [
     url: 'https://core.vmware.com/resource/vmware-vsan-express-storage-architecture',
   },
   {
-    name: 'vSAN ESA RAID-6: 8 hosts, 160 drives - Large cluster (6+2)',
+    name: 'vSAN ESA RAID-6: 8 hosts, 160 drives - Still fixed 4+2',
     level: 'vsan_esa_raid6',
     drives: 160,
     driveSize: TB,
     serverCount: 8,
-    expectedEfficiency: 0.75, // 75% efficiency (6+2 scheme)
+    // RAID-6 stays 4+2 regardless of cluster size (only RAID-5 is adaptive)
+    expectedEfficiency: 0.667, // 67% efficiency (4+2 scheme)
     tolerance: 0.03,
     source: 'VMware vSAN ESA Documentation',
     url: 'https://core.vmware.com/resource/vmware-vsan-express-storage-architecture',
   },
   {
-    name: 'vSAN ESA RAID-6: 10 hosts, 240 drives - Large cluster (6+2)',
+    name: 'vSAN ESA RAID-6: 10 hosts, 240 drives - Still fixed 4+2',
     level: 'vsan_esa_raid6',
     drives: 240,
     driveSize: TB,
     serverCount: 10,
-    expectedEfficiency: 0.75, // 75% efficiency (6+2 scheme)
+    // RAID-6 stays 4+2 regardless of cluster size (only RAID-5 is adaptive)
+    expectedEfficiency: 0.667, // 67% efficiency (4+2 scheme)
     tolerance: 0.03,
     source: 'VMware vSAN ESA Documentation',
     url: 'https://core.vmware.com/resource/vmware-vsan-express-storage-architecture',


### PR DESCRIPTION
## Summary
Resolves the two **vSAN ESA known limitations** recorded in v1.9.0 — the model's adaptive erasure-coding now matches VMware/Broadcom documentation.

- **Adaptive RAID-5** switches to **4+1 (80%)** at **≥6 hosts** (host-count only), as VMware documents — previously it triggered at ≥5 hosts *and* required ≥100 drives. 3–5 host clusters correctly stay **2+1 (67%)**.
- **RAID-6** is now a **fixed 4+2 (67%)** stripe regardless of cluster size — removed the incorrect **6+2 (75%)** scheme the model applied at ≥8 hosts. (VMware: *"RAID-6 erasure coding remains a 4+2 scheme regardless of the cluster size"*; only RAID-5 is adaptive.)

## Changes
- `src/engines/volumetry/strategies/vsan.ts` — the two ESA formulas.
- `tests/fixtures/vsan-vectors.ts` + `tests/engines/volumetry.spec.ts` — vectors and threshold/stripe-width tests updated to VMware-correct values.
- Bump to **1.9.1**; changelog entry resolving the 1.9.0 known limitations.

UI/i18n guide strings already stated the canonical values, so no guide changes were needed.

## Verification
`npm run typecheck` ✅ · `biome check` ✅ · `vitest` ✅ **928 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated vSAN ESA capacity calculations to match expected cluster behavior.
  * RAID-5 now switches to the higher-efficiency layout only at larger cluster sizes, while smaller clusters keep the lower-efficiency layout.
  * RAID-6 now reports a consistent 4+2 stripe layout across cluster sizes, preventing incorrect higher-efficiency estimates.
  * Included matching updates to validation coverage and release version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->